### PR TITLE
Feature / Unproject when unmounting multiview

### DIFF
--- a/src/components/VideoPlayerContainer.vue
+++ b/src/components/VideoPlayerContainer.vue
@@ -38,8 +38,8 @@
         class="player"
         :class="{
           show: show,
-          'limit-screen': sourceRemoteTracks.length && isSplittedView && !isGrid,
-          'grid-player': sourceRemoteTracks.length && isSplittedView && isGrid
+          'limit-screen': videoSources.length > 1 && isSplittedView && !isGrid,
+          'grid-player': videoSources.length > 1 && isSplittedView && isGrid
         }"
         :style="{
         cursor: isGrid? 'pointer' : '',
@@ -102,9 +102,9 @@
       </div>
       <!-- SIDE SOURCES -->
       <div
+        v-if="videoSources.length > 1 && isSplittedView"
         :class="!isGrid ? 'side-panel overflow-auto sc1': ''"
         :style="!isGrid ? 'scroll-snap-type: y mandatory': 'display: contents'"
-        v-if="sourceRemoteTracks.length && isSplittedView"
         @mousemove="showControls"
       >
         <VideoPlayerSideVideoSources :class="isGrid ? 'side-sources' : ''"/>

--- a/src/components/VideoPlayerMedia.vue
+++ b/src/components/VideoPlayerMedia.vue
@@ -36,7 +36,7 @@
     ></video>
   </template>
   <span
-    v-if="sourceRemoteTracks.length && isSplittedView && !fullscreen && viewer.showLabels"
+    v-if="videoSources.length > 1 && isSplittedView && !fullscreen && viewer.showLabels"
   >
     {{this.mainLabel}}
   </span>
@@ -91,7 +91,6 @@ export default {
       selectedAudioSource: (state) => state.selectedAudioSource,
       audioSources: (state) => state.audioSources,
       videoSources: (state) => state.videoSources,
-      sourceRemoteTracks: (state) => state.sourceRemoteTracks,
       mainLabel: (state) => state.mainLabel,
     }),
     ...mapState('Controls', {

--- a/src/components/VideoPlayerSideVideoSources.vue
+++ b/src/components/VideoPlayerSideVideoSources.vue
@@ -37,6 +37,7 @@ import {
   selectSource,
   projectRemoteTracks,
   projectVideo,
+  unprojectMultiview,
 } from '../service/sdkManager'
 
 export default {
@@ -82,11 +83,17 @@ export default {
     this.videoSources.forEach(source => {
       this.transceiverSourceState[source.mid] = source
     })
+    unprojectMultiview()
   },
   watch: {
-    'sourceRemoteTracks.length': async function () {
-      await projectRemoteTracks(this.sourceRemoteTracks[this.sourceRemoteTracks.length - 1])
-    },
+    'sourceRemoteTracks.length': {
+      handler: async function (newLenght, currentLenght) {
+        if (newLenght > currentLenght) {
+          const lastIndex = newLenght - 1
+          await projectRemoteTracks(this.sourceRemoteTracks[lastIndex])
+        } 
+      },
+    }
   },
   methods: {
     ...mapMutations('Controls', ['toggleFullscreen', 'setIsSplittedView']),

--- a/src/components/VideoPlayerSideVideoSources.vue
+++ b/src/components/VideoPlayerSideVideoSources.vue
@@ -72,11 +72,11 @@ export default {
   },
   async mounted() {
     selectSource({ kind: 'video', source: this.videoSources[0] })
-    this.setMainLabel('Main')
+    this.setMainLabel(this.videoSources[0].name)
     this.sourceRemoteTracks.forEach(async (remoteTrack) =>
       await projectRemoteTracks(remoteTrack)
     )
-    
+
     this.playerRef = document.getElementById('player')
   },
   async unmounted() {
@@ -108,14 +108,14 @@ export default {
       // Select the source from the transceiver state and project it in the main video
       let source = this.transceiverSourceState[videoMid]
       let lowQualityLayer
-      let midProjectedInMain = 0
+      let midProjectedInMain = this.videoSources[0].mid
 
       if (this.getVideoHasMain) {
-        sideLabelRef.textContent = this.transceiverSourceState[0].name        
-        sideLabelRef.textContent = this.transceiverSourceState[0].name
+        sideLabelRef.textContent = this.transceiverSourceState[midProjectedInMain].name        
+
+        const sourceIdProjectedInMain = this.transceiverSourceState[midProjectedInMain].sourceId
+        midProjectedInMain = this.transceiverSourceState[midProjectedInMain].mid
         
-        const sourceIdProjectedInMain = this.transceiverSourceState[0].sourceId
-        midProjectedInMain = this.transceiverSourceState[0].mid
         if (midProjectedInMain in this.getActiveMedias()) {
           lowQualityLayer = this.getActiveMedias()[midProjectedInMain].layers.slice(-1)[0]
         }
@@ -125,11 +125,11 @@ export default {
           this.transceiverSourceState[midProjectedInMain].trackId, 
           lowQualityLayer
         )
+        this.updateTransceiverSourceState({ source })
       }
 
       this.setMainLabel(source.sourceId ?? 'Main')
       await selectSource({ kind: 'video', source })
-      this.updateTransceiverSourceState({ source })
 
       if (this.isGrid) {
         this.setIsSplittedView(false)

--- a/src/components/VideoPlayerStatsTable.vue
+++ b/src/components/VideoPlayerStatsTable.vue
@@ -203,7 +203,10 @@ export default {
     ...mapState('ViewConnection', {
       millicastView: (state) => state.millicastView,
     }),
-    ...mapState('Sources', ['sourceRemoteTracks']),
+    ...mapState('Sources', [
+      'sourceRemoteTracks', 
+      'videoSources'
+    ]),
     ...mapGetters('Sources', [
       'getTransceiverSourceState'
     ]),
@@ -279,7 +282,7 @@ export default {
     },
     multiviewStatsAvailable() {
       const multiviewIsOn = (
-        this.sourceRemoteTracks.length && 
+        this.videoSources.length > 1 && 
         this.isSplittedView && 
         Object.keys(this.midToStatsIndexMap).length
       )

--- a/src/service/sdkManager.js
+++ b/src/service/sdkManager.js
@@ -181,6 +181,10 @@ export const projectVideo = async (what, where, trackId, layer) => {
   sources.handleProjectVideo(what, where, trackId, layer)
 }
 
+export const unprojectMultiview = async () => {
+  sources.handleUnprojectMultiview()
+}
+
 // CAST
 
 export const setCast = async () => {

--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -221,3 +221,9 @@ export const handleProjectRemoteTracks = async (remoteTrack) => {
   sidePlayerVideo.playsInline = true
   sidePlayerVideo.play()
 }
+
+export const handleUnprojectMultiview = async () => {
+  const mids = state.ViewConnection.millicastView.webRTCPeer.peer.getTransceivers()
+    .splice(2).map((vt) => { return vt.mid })
+  state.ViewConnection.millicastView.unproject(mids)
+}


### PR DESCRIPTION
When the Multiview is hidden, the side video sources are unmounted using the "unproject" command. The purpose of this is to prevent unnecessary bandwidth consumption.