### PR TITLE
Fix / Added behavior for multiview without main source

### DIFF
--- a/src/components/VideoPlayerContainer.vue
+++ b/src/components/VideoPlayerContainer.vue
@@ -38,8 +38,8 @@
         class="player"
         :class="{
           show: show,
-          'limit-screen': sourceRemoteTracks.length && isSplittedView && !isGrid,
-          'grid-player': sourceRemoteTracks.length && isSplittedView && isGrid
+          'limit-screen': videoSources.length > 1 && isSplittedView && !isGrid,
+          'grid-player': videoSources.length > 1 && isSplittedView && isGrid
         }"
         :style="{
         cursor: isGrid? 'pointer' : '',
@@ -102,9 +102,9 @@
       </div>
       <!-- SIDE SOURCES -->
       <div
+        v-if="videoSources.length > 1 && isSplittedView"
         :class="!isGrid ? 'side-panel overflow-auto sc1': ''"
         :style="!isGrid ? 'scroll-snap-type: y mandatory': 'display: contents'"
-        v-if="sourceRemoteTracks.length && isSplittedView"
         @mousemove="showControls"
       >
         <VideoPlayerSideVideoSources :class="isGrid ? 'side-sources' : ''"/>

--- a/src/components/VideoPlayerMedia.vue
+++ b/src/components/VideoPlayerMedia.vue
@@ -36,7 +36,7 @@
     ></video>
   </template>
   <span
-    v-if="sourceRemoteTracks.length && isSplittedView && !fullscreen && viewer.showLabels"
+    v-if="videoSources.length > 1 && isSplittedView && !fullscreen && viewer.showLabels"
   >
     {{this.mainLabel}}
   </span>
@@ -91,7 +91,6 @@ export default {
       selectedAudioSource: (state) => state.selectedAudioSource,
       audioSources: (state) => state.audioSources,
       videoSources: (state) => state.videoSources,
-      sourceRemoteTracks: (state) => state.sourceRemoteTracks,
       mainLabel: (state) => state.mainLabel,
     }),
     ...mapState('Controls', {

--- a/src/components/VideoPlayerSideVideoSources.vue
+++ b/src/components/VideoPlayerSideVideoSources.vue
@@ -72,7 +72,7 @@ export default {
   },
   async mounted() {
     selectSource({ kind: 'video', source: this.videoSources[0] })
-    this.setMainLabel('Main')
+    this.setMainLabel(this.videoSources[0].name)
     this.sourceRemoteTracks.forEach(async (remoteTrack) =>
       await projectRemoteTracks(remoteTrack)
     )
@@ -108,14 +108,14 @@ export default {
       // Select the source from the transceiver state and project it in the main video
       let source = this.transceiverSourceState[videoMid]
       let lowQualityLayer
-      let midProjectedInMain = 0
+      let midProjectedInMain = this.videoSources[0].mid
 
       if (this.getVideoHasMain) {
-        sideLabelRef.textContent = this.transceiverSourceState[0].name        
-        sideLabelRef.textContent = this.transceiverSourceState[0].name
+        sideLabelRef.textContent = this.transceiverSourceState[midProjectedInMain].name        
+
+        const sourceIdProjectedInMain = this.transceiverSourceState[midProjectedInMain].sourceId
+        midProjectedInMain = this.transceiverSourceState[midProjectedInMain].mid
         
-        const sourceIdProjectedInMain = this.transceiverSourceState[0].sourceId
-        midProjectedInMain = this.transceiverSourceState[0].mid
         if (midProjectedInMain in this.getActiveMedias()) {
           lowQualityLayer = this.getActiveMedias()[midProjectedInMain].layers.slice(-1)[0]
         }
@@ -125,11 +125,11 @@ export default {
           this.transceiverSourceState[midProjectedInMain].trackId, 
           lowQualityLayer
         )
+        this.updateTransceiverSourceState({ source })
       }
 
       this.setMainLabel(source.sourceId ?? 'Main')
       await selectSource({ kind: 'video', source })
-      this.updateTransceiverSourceState({ source })
 
       if (this.isGrid) {
         this.setIsSplittedView(false)

--- a/src/components/VideoPlayerStatsTable.vue
+++ b/src/components/VideoPlayerStatsTable.vue
@@ -203,7 +203,10 @@ export default {
     ...mapState('ViewConnection', {
       millicastView: (state) => state.millicastView,
     }),
-    ...mapState('Sources', ['sourceRemoteTracks']),
+    ...mapState('Sources', [
+      'sourceRemoteTracks', 
+      'videoSources'
+    ]),
     ...mapGetters('Sources', [
       'getTransceiverSourceState'
     ]),
@@ -279,7 +282,7 @@ export default {
     },
     multiviewStatsAvailable() {
       const multiviewIsOn = (
-        this.sourceRemoteTracks.length && 
+        this.videoSources.length > 1 && 
         this.isSplittedView && 
         Object.keys(this.midToStatsIndexMap).length
       )


### PR DESCRIPTION
The behavior for multiview initialization without the Main source has been enhanced. Now, when multiview initializes without the Main source, the viewer will display a side source as the main one. Similarly, if the Main source becomes disconnected, the viewer will automatically switch to a side source as the new Main source.