### PR TITLE
Fix reconnection toast

### DIFF
--- a/src/components/VideoPlayerMedia.vue
+++ b/src/components/VideoPlayerMedia.vue
@@ -159,11 +159,11 @@ export default {
         toast.warning(message, toastOptions)
       } else {
         const setSplitView = (state) => {
-            if (['connected'].includes(state)) {
-              this.setIsSplittedView(this.previousSplitState)
-              this.millicastView.removeListener('connectionStateChange', setSplitView)
-              toast.clear()
-            }
+          if (['connected'].includes(state)) {
+            this.setIsSplittedView(this.previousSplitState)
+            this.millicastView.removeListener('connectionStateChange', setSplitView)
+            toast.clear()
+          }
         }
         this.millicastView.on('connectionStateChange', setSplitView)
       }

--- a/src/components/VideoPlayerMedia.vue
+++ b/src/components/VideoPlayerMedia.vue
@@ -147,17 +147,23 @@ export default {
   },
   watch: {
     reconnectionStatus: function (isReconnecting) {
+      let toastOptions;
       const toast = useToast()
       toast.clear()
       if (isReconnecting) {
         this.setIsSplittedView(false)
-        toast.warning(`Connection lost. Retrying...`)
+        const message = 'Connection lost. Retrying...'
+        if (this.reconnection?.timeout) {
+          toastOptions = { timeout: this.reconnection?.timeout }
+        }
+        toast.warning(message, toastOptions)
       } else {
         const setSplitView = (state) => {
-          if (['connected'].includes(state)) {
-            this.setIsSplittedView(this.previousSplitState)
-            this.millicastView.removeListener('connectionStateChange', setSplitView)
-          }
+            if (['connected'].includes(state)) {
+              this.setIsSplittedView(this.previousSplitState)
+              this.millicastView.removeListener('connectionStateChange', setSplitView)
+              toast.clear()
+            }
         }
         this.millicastView.on('connectionStateChange', setSplitView)
       }


### PR DESCRIPTION
When connection is lost, it uses the timeout from the reconnection error to show a countdown bar in the warning toast.

In order to test it, connect to a stream, disconnect from internet, wait a few seconds (for the websocket to close) and it should appear the toast with the countdown bar spending more time each iteration (until 32 seconds). When connection is up again (internet turned on again) and the stream is visible, the toast should go away.