### PR TITLE
Fix / Main source label display wrong name

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -51,7 +51,7 @@ export default {
           multisource: this.paramsOptions?.multisource ?? false,
           layout: this.paramsOptions?.layout ?? null,
           showLabels: this.paramsOptions?.showLabels ?? true,
-          mainLabel: this.paramsOptions?.mainLabel ?? null
+          mainLabel: this.paramsOptions?.mainLabel ?? 'Main'
         })
       }
       processEnvironmentOptions(this.paramsOptions?.environment)

--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -84,14 +84,13 @@ const addSource = (kind, sourceId, trackId) => {
         kind === 'video'
           ? state.Sources.selectedVideoSource
           : state.Sources.selectedAudioSource
-
-      if (selectedMediaSource.name !== mainLabel) {
+      if (selectedMediaSource.name !== state.Params.viewer.mainLabel) {
         commit('Sources/setSelectedSource', {
           kind,
           selectedSource: source,
         })
         handleSelectSource({ kind, source })
-        commit('Sources/setMainLabel', mainLabel)
+        commit('Sources/setMainLabel', state.Params.viewer.mainLabel)
       }
     } else {
       sources.push(source)


### PR DESCRIPTION
If the main sources is not the first one to arrive, the label of the main sources ends with a wrong name. It ends with the name of the first source to arrive.