### PR TITLE
fix/Wrong audio track labeling when main source returns from inactive

### DIFF
--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -67,9 +67,8 @@ const tracksAvailableAndMainNotExists = () => {
 }
 
 const addSource = (kind, sourceId, trackId) => {
-  const mainLabel = state.Params.viewer.mainLabel ?  state.Params.viewer.mainLabel  : 'Main'
   const source = {
-    name: sourceId === null ? mainLabel : sourceId,
+    name: sourceId === null ? state.Params.viewer.mainLabel : sourceId,
     sourceId,
     trackId,
     mid: sourceId === null ? (kind === 'video' ? "0" : "1") : null

--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -67,7 +67,7 @@ const tracksAvailableAndMainNotExists = () => {
 }
 
 const addSource = (kind, sourceId, trackId) => {
-  const mainLabel = state.Sources.mainLabel
+  const mainLabel = state.Params.viewer.mainLabel ?  state.Params.viewer.mainLabel  : 'Main'
   const source = {
     name: sourceId === null ? mainLabel : sourceId,
     sourceId,


### PR DESCRIPTION
An issue occurred during the initialization of the connection when the first active event without audio was received from a source. Subsequently, the active event of a source arrived with a null source ID, which resulted in an inconsistency issue with the label name of the main source in the audio tracks settings dropdown.