### PR TITLE
fix/Side sources switch correctly when showLabels parameter equals false

### DIFF
--- a/src/components/VideoPlayerControls/VideoPlayerControlsSettingsAudioTrack.vue
+++ b/src/components/VideoPlayerControls/VideoPlayerControlsSettingsAudioTrack.vue
@@ -17,7 +17,7 @@
       class="dropdown-item-name mr-auto"
       :class="[
         this.selectedAudioSource.name === 'none' ? 'none' : '',
-        this.selectedAudioSource.sourceId === null ? this.selectedAudioSource.name : '',
+        this.selectedAudioSource.sourceId === null ? 'main' : ''
       ]"
     >
       <span

--- a/src/components/VideoPlayerSideVideoSources.vue
+++ b/src/components/VideoPlayerSideVideoSources.vue
@@ -103,7 +103,6 @@ export default {
       await nextTick()
       this.enableClick = false
       this.playerRef = document.getElementById(this.currentElementRef)
-      const sideLabelRef = this.$refs[`sideLabel${videoMid}`][0]
 
       // Select the source from the transceiver state and project it in the main video
       let source = this.transceiverSourceState[videoMid]
@@ -111,7 +110,9 @@ export default {
       let midProjectedInMain = this.videoSources[0].mid
 
       if (this.getVideoHasMain) {
-        sideLabelRef.textContent = this.transceiverSourceState[midProjectedInMain].name        
+        if (this.viewer.showLabels) {
+          this.$refs[`sideLabel${videoMid}`][0].textContent = this.transceiverSourceState[midProjectedInMain].name        
+        }
 
         const sourceIdProjectedInMain = this.transceiverSourceState[midProjectedInMain].sourceId
         midProjectedInMain = this.transceiverSourceState[midProjectedInMain].mid

--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -158,15 +158,21 @@ const deleteSource = (kind, sourceId) => {
     if (state.Controls.isSplittedView) {
       if (state.Sources.selectedVideoSource.sourceId !== null && sourceId === null) {
         handleProjectVideo(state.Sources.selectedVideoSource.sourceId, `${sourceCurrentMid}`, state.Sources.selectedVideoSource.trackId)
-        document.getElementById(`sideLabel${state.Sources.selectedVideoSource.mid}`).textContent = state.Sources.selectedVideoSource.sourceId
+        if (state.viewer.showLabels) {
+          document.getElementById(`sideLabel${state.Sources.selectedVideoSource.mid}`).textContent = state.Sources.selectedVideoSource.sourceId
+        }
       } else if (state.Sources.selectedVideoSource.sourceId === null && sourceId !== null) {
         if (sourceCurrentMid !== sourceInitialMid) {
           handleProjectVideo(state.Sources.transceiverSourceState[sourceInitialMid].sourceId, state.Sources.transceiverSourceState[sourceCurrentMid].mid)
-          document.getElementById(`sideLabel${state.Sources.transceiverSourceState[sourceCurrentMid].mid}`).textContent = state.Sources.transceiverSourceState[sourceInitialMid].sourceId
+          if (state.viewer.showLabels) {
+            document.getElementById(`sideLabel${state.Sources.transceiverSourceState[sourceCurrentMid].mid}`).textContent = state.Sources.transceiverSourceState[sourceInitialMid].sourceId
+          }
         }
       } else if (state.Sources.selectedVideoSource.sourceId !== null && sourceId !== null && sourceCurrentMid !== sourceInitialMid) {
         handleProjectVideo(state.Sources.transceiverSourceState[sourceInitialMid].sourceId, state.Sources.selectedVideoSource.mid)
-        document.getElementById(`sideLabel${state.Sources.transceiverSourceState[state.Sources.selectedVideoSource.mid].mid}`).textContent = state.Sources.transceiverSourceState[sourceInitialMid].sourceId
+        if (state.viewer.showLabels) {
+          document.getElementById(`sideLabel${state.Sources.transceiverSourceState[state.Sources.selectedVideoSource.mid].mid}`).textContent = state.Sources.transceiverSourceState[sourceInitialMid].sourceId
+        }
       }
     }
 


### PR DESCRIPTION
When the `showLabels` parameter is set to `false` and multisource is `true`, users cannot switch a sources to the main view.