### PR TITLE
Fix/side source removes the incorrect video when connection is lost

### DIFF
--- a/src/components/VideoPlayerSideVideoSources.vue
+++ b/src/components/VideoPlayerSideVideoSources.vue
@@ -91,7 +91,11 @@ export default {
         if (newLenght > currentLenght) {
           const lastIndex = newLenght - 1
           await projectRemoteTracks(this.sourceRemoteTracks[lastIndex])
-        } 
+        } else {
+          this.sourceRemoteTracks.forEach(async (remoteTrack) =>
+            await projectRemoteTracks(remoteTrack)
+          )
+        }
       },
     }
   },

--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -158,19 +158,19 @@ const deleteSource = (kind, sourceId) => {
     if (state.Controls.isSplittedView) {
       if (state.Sources.selectedVideoSource.sourceId !== null && sourceId === null) {
         handleProjectVideo(state.Sources.selectedVideoSource.sourceId, `${sourceCurrentMid}`, state.Sources.selectedVideoSource.trackId)
-        if (state.viewer.showLabels) {
+        if (state.Params.viewer.showLabels) {
           document.getElementById(`sideLabel${state.Sources.selectedVideoSource.mid}`).textContent = state.Sources.selectedVideoSource.sourceId
         }
       } else if (state.Sources.selectedVideoSource.sourceId === null && sourceId !== null) {
         if (sourceCurrentMid !== sourceInitialMid) {
           handleProjectVideo(state.Sources.transceiverSourceState[sourceInitialMid].sourceId, state.Sources.transceiverSourceState[sourceCurrentMid].mid)
-          if (state.viewer.showLabels) {
+          if (state.Params.viewer.showLabels) {
             document.getElementById(`sideLabel${state.Sources.transceiverSourceState[sourceCurrentMid].mid}`).textContent = state.Sources.transceiverSourceState[sourceInitialMid].sourceId
           }
         }
       } else if (state.Sources.selectedVideoSource.sourceId !== null && sourceId !== null && sourceCurrentMid !== sourceInitialMid) {
         handleProjectVideo(state.Sources.transceiverSourceState[sourceInitialMid].sourceId, state.Sources.selectedVideoSource.mid)
-        if (state.viewer.showLabels) {
+        if (state.Params.viewer.showLabels) {
           document.getElementById(`sideLabel${state.Sources.transceiverSourceState[state.Sources.selectedVideoSource.mid].mid}`).textContent = state.Sources.transceiverSourceState[sourceInitialMid].sourceId
         }
       }


### PR DESCRIPTION
- The issue occurs when dropping the connection on one of the side sources, resulting in a significant drop in frame rate and unexpected behavior. Specifically, the other videos disappear, and the labels become incorrect.