### PR TITLE
Feature/ Add option for audio-follows-video

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -49,6 +49,7 @@ export default {
           muted: this.paramsOptions.muted ?? false,
           noDelay: this.paramsOptions?.noDelay ?? false,
           multisource: this.paramsOptions?.multisource ?? false,
+          audioFollowsVideo: this.paramsOptions?.audioFollowsVideo ?? false,
           layout: this.paramsOptions?.layout ?? null,
           showLabels: this.paramsOptions?.showLabels ?? true,
           mainLabel: this.paramsOptions?.mainLabel ?? 'Main'

--- a/src/components/VideoPlayerControls/VideoPlayerControlsSettings.vue
+++ b/src/components/VideoPlayerControls/VideoPlayerControlsSettings.vue
@@ -105,6 +105,12 @@ export default {
       dropupTitle: '',
       handleClick: function () {},
       compare: function () {},
+      audioFollowVideoData: {
+        mid: null,
+        name: 'AudioFollowVideo',
+        sourceId: 'AudioFollowVideo',
+        trackId: null,
+      }
     }
   },
   computed: {
@@ -121,6 +127,7 @@ export default {
     ...mapState('Sources', {
       selectedVideoSource: (state) => state.selectedVideoSource,
       selectedAudioSource: (state) => state.selectedAudioSource,
+      audioFollowsVideo: (state) => state.audioFollowsVideo,
     }),
     ...mapState('Controls', {
       dropup: (state) => state.dropup,
@@ -135,6 +142,7 @@ export default {
     ]),
     ...mapMutations('Sources', [
       'setMainLabel',
+      'setAudioFollowsVideo',
     ]),
     compareItems(entry, current) {
       return entry?.name === current?.name && (entry?.id === current?.id || current?.name === 'Auto')
@@ -222,18 +230,32 @@ export default {
           }
           case 'audioTracks': {
             const audioTrackChange = async (source) => {
-              try {
-                await selectSource({ kind: 'audio', source })
-              } catch (error) {
-                this.toast.error(
-                  'There was an error selecting the desired source, try again',
-                  { timeout: 5000 }
-                )
+              if(source.name === 'AudioFollowVideo') {
+                this.setAudioFollowsVideo(true)
+              } else {
+                this.setAudioFollowsVideo(false)
+                try {
+                  await selectSource({ kind: 'audio', source })
+                } catch (error) {
+                  this.toast.error(
+                    'There was an error selecting the desired source, try again',
+                    { timeout: 5000 }
+                  )
+                }
               }
             }
+            const getAudioTracks = () => {
+              return [this.audioFollowVideoData, ...this.getAudioSources]
+            }
+            const getAudioSourceSelected = () => {
+              if (this.audioFollowsVideo) {
+                return this.audioFollowVideoData
+              }
+              return this.selectedAudioSource
+            }
             this.setDropupSettings(
-              this.selectedAudioSource,
-              this.getAudioSources,
+              getAudioSourceSelected(),
+              getAudioTracks(),
               'Audio Source',
               audioTrackChange,
               this.compareSources

--- a/src/components/VideoPlayerSideVideoSources.vue
+++ b/src/components/VideoPlayerSideVideoSources.vue
@@ -54,7 +54,9 @@ export default {
     ...mapState('Sources', [
       'sourceRemoteTracks',
       'videoSources',
+      'audioSources',
       'transceiverSourceState',
+      'audioFollowsVideo',
     ]),
     ...mapState('Controls', {
         fullscreen: state => state.fullscreen, 
@@ -112,6 +114,8 @@ export default {
       let source = this.transceiverSourceState[videoMid]
       let lowQualityLayer
       let midProjectedInMain = this.videoSources[0].mid
+      const sourceName =  source.name
+      const audioSource = this.audioSources.find(currentSoruce => currentSoruce.name === sourceName)
 
       if (this.getVideoHasMain) {
         if (this.viewer.showLabels) {
@@ -138,6 +142,17 @@ export default {
 
       if (this.isGrid) {
         this.setIsSplittedView(false)
+      }
+
+      if ( audioSource && this.audioFollowsVideo ) {
+        try {
+          await selectSource({ kind: 'audio', source: audioSource })
+        } catch (error) {
+          this.toast.error(
+            'There was an error selecting the desired source, try again',
+            { timeout: 5000 }
+          )
+        }
       }
 
       this.enableClick = true

--- a/src/service/viewerOptions.js
+++ b/src/service/viewerOptions.js
@@ -15,6 +15,7 @@ export const defaultViewerOptions = {
   token: null,
   forcePlayoutDelay: false,
   multisource: false,
+  audioFollowsVideo: false,
   layout: null,
   showLabels: true,
   mainLabel: null
@@ -32,6 +33,7 @@ export default function processViewerOptions({
   muted,
   noDelay,
   multisource,
+  audioFollowsVideo,
   layout,
   showLabels,
   mainLabel
@@ -48,10 +50,14 @@ export default function processViewerOptions({
   options.autoplay = autoplay ?? true
   options.muted = muted ?? false
   options.multisource = multisource ?? false
+  options.audioFollowsVideo = audioFollowsVideo ?? false
   options.layout = layout
   options.showLabels = showLabels
   if (multisource) {
     store.commit('Controls/setIsSplittedView', true)
+  }
+  if (audioFollowsVideo) {
+    store.commit('Sources/setAudioFollowsVideo', true)
   }
   if (noDelay) {
     options.forcePlayoutDelay = { min: 0, max: 0 }

--- a/src/store/modules/sources.js
+++ b/src/store/modules/sources.js
@@ -8,6 +8,7 @@ const defaulState = {
     name: 'none',
   },
   isAudioOnly: false,
+  audioFollowsVideo: false,
   stream: null,
   sourceRemoteTracks: [],
   mainLabel: 'Main',
@@ -54,6 +55,9 @@ export default {
     },
     setIsAudioOnly(state, isAudioOnly) {
       state.isAudioOnly = isAudioOnly
+    },
+    setAudioFollowsVideo(state, audioFollowsVideo) {
+      state.audioFollowsVideo = audioFollowsVideo
     },
     addSourceRemoteTrack(state, sourceRemoteTrack) {
       state.sourceRemoteTracks.push(sourceRemoteTrack)


### PR DESCRIPTION
We should implement an option that can be selected in the gear menu of the hosted player.  This audio option has the following requirements:

- NOT the default option
- available only if multiple audio tracks exist
- when this option is chosen, when a user switches to a video that contains audio the audio will change to match the video.  If the video does not contain audio track and is video-only, the last audio track will play until a video that has matched audio is chosen.
- the user can switch back to an explicit audio track at any time and audio will no longer follow video

How to enable this option 

- Audio Source > Audio Follows Video (top option in the list)
- Add a queryParam for audioFollowsVideo=true/false