### PR TITLE
fix/ Media stats are not working in hosted player for Multisource str…

### DIFF
--- a/src/components/VideoPlayerStatsTable.vue
+++ b/src/components/VideoPlayerStatsTable.vue
@@ -168,7 +168,8 @@ export default {
       })
       this.stats = { ...this.stats, ...peerStats }
     })
-    this.selectedSourceMid = this.getTransceiverSourceState[0].mid
+    this.selectedSourceMid = this.getTransceiverSourceState[0]?.mid 
+      ?? Object.values(this.getTransceiverSourceState)[0].mid
   },
   beforeUnmount() {
     this.millicastView.webRTCPeer.stopStats()
@@ -192,7 +193,8 @@ export default {
       this.statsIndex = this.midToStatsIndexMap[mid]
     },
     selectMidZero() {
-      this.selectedSourceMid = this.getTransceiverSourceState[0].mid
+      this.selectedSourceMid = this.getTransceiverSourceState[0]?.mid 
+        ?? Object.values(this.getTransceiverSourceState)[0].mid
     },
   },
   computed: {


### PR DESCRIPTION
…eam without main source

**Description:**
- When we start a multisource streaming from any channel the viewer plugin does not show the media stats and it throws the error logs in console. 

**Steps to reproduce:**
- Start a stream without a Main source
- Go to the stats

**Expected behavior:**
- User should be able to view the media stat when multisource is enabled using hosted player.

**Actual result:**
- Stats information is not shown
- There are some errors on the browser console