### PR TITLE
v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@millicast/vue-viewer-plugin",
-            "version": "1.1.3",
+            "version": "1.2.0",
             "license": "See in LICENSE file",
             "dependencies": {
                 "@millicast/sdk": "^0.1.41",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "private": false,
     "author": "Millicast, Inc.",
     "scripts": {


### PR DESCRIPTION
Release of Viewer Plugin v1.2.0. The release includes:

**Added**
- Audio follows video: now, when audio follows video is enabled, and a source with audio tracks is selected, the viewer switches the audio source to the one associated with the selected video source.
- New option under `settings wheel/audio sources` for enabling (or disabling) audio-follows-video in the player.
- New `audioFollowsVideo` query parameter for enabling (or disabling) audio-follows-video in the player.
- Added the `audioFollowsVideo` option to the `README` file.

**Fixed**
- Now, when a side source connection is lost, the correct source is removed.
- Displaying the correct audio track names on the `settings wheel/audio sources` list.
- MultiView works properly when `&showLabels` is set to false.
- Media stats work as intended for Multi-source streams without a main source.