### PR TITLE
v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can now use the plugin in any Vue file of your project as a component.
 | `showLabels`   | `Boolean`        | Optional  | `true`              | Show stream label in multiview mode.                                                                 |
 | `environment`  | `Object`         | Optional  | `.env file content` | Plugin environment. See [Environment options](#environment-options) on how to configure.             |
 | `mainLabel`    | `String`         | Optional  |                     | Allows to change the label of the main video.                                                        |
+| `audioFollowsVideo`| `Boolean`    | Optional  | `false`             | Allows automatically switching the audio to the one associated with the selected video source.       |
 
 To be able to use the viewer, just reference the `VideoPlayer` component, and pass the parameters of your choice as an object in the parameter `paramsOptions`. Refer to the [example usage](#example-apps).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@millicast/vue-viewer-plugin",
-            "version": "1.1.3",
+            "version": "1.2.0",
             "license": "See in LICENSE file",
             "dependencies": {
                 "@millicast/sdk": "^0.1.41",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "private": false,
     "author": "Millicast, Inc.",
     "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -49,6 +49,7 @@ export default {
           muted: this.paramsOptions.muted ?? false,
           noDelay: this.paramsOptions?.noDelay ?? false,
           multisource: this.paramsOptions?.multisource ?? false,
+          audioFollowsVideo: this.paramsOptions?.audioFollowsVideo ?? false,
           layout: this.paramsOptions?.layout ?? null,
           showLabels: this.paramsOptions?.showLabels ?? true,
           mainLabel: this.paramsOptions?.mainLabel ?? 'Main'

--- a/src/components/VideoPlayerControls/VideoPlayerControlsSettings.vue
+++ b/src/components/VideoPlayerControls/VideoPlayerControlsSettings.vue
@@ -105,6 +105,12 @@ export default {
       dropupTitle: '',
       handleClick: function () {},
       compare: function () {},
+      audioFollowVideoData: {
+        mid: null,
+        name: 'AudioFollowVideo',
+        sourceId: 'AudioFollowVideo',
+        trackId: null,
+      }
     }
   },
   computed: {
@@ -121,6 +127,7 @@ export default {
     ...mapState('Sources', {
       selectedVideoSource: (state) => state.selectedVideoSource,
       selectedAudioSource: (state) => state.selectedAudioSource,
+      audioFollowsVideo: (state) => state.audioFollowsVideo,
     }),
     ...mapState('Controls', {
       dropup: (state) => state.dropup,
@@ -135,6 +142,7 @@ export default {
     ]),
     ...mapMutations('Sources', [
       'setMainLabel',
+      'setAudioFollowsVideo',
     ]),
     compareItems(entry, current) {
       return entry?.name === current?.name && (entry?.id === current?.id || current?.name === 'Auto')
@@ -222,18 +230,32 @@ export default {
           }
           case 'audioTracks': {
             const audioTrackChange = async (source) => {
-              try {
-                await selectSource({ kind: 'audio', source })
-              } catch (error) {
-                this.toast.error(
-                  'There was an error selecting the desired source, try again',
-                  { timeout: 5000 }
-                )
+              if(source.name === 'AudioFollowVideo') {
+                this.setAudioFollowsVideo(true)
+              } else {
+                this.setAudioFollowsVideo(false)
+                try {
+                  await selectSource({ kind: 'audio', source })
+                } catch (error) {
+                  this.toast.error(
+                    'There was an error selecting the desired source, try again',
+                    { timeout: 5000 }
+                  )
+                }
               }
             }
+            const getAudioTracks = () => {
+              return [this.audioFollowVideoData, ...this.getAudioSources]
+            }
+            const getAudioSourceSelected = () => {
+              if (this.audioFollowsVideo) {
+                return this.audioFollowVideoData
+              }
+              return this.selectedAudioSource
+            }
             this.setDropupSettings(
-              this.selectedAudioSource,
-              this.getAudioSources,
+              getAudioSourceSelected(),
+              getAudioTracks(),
               'Audio Source',
               audioTrackChange,
               this.compareSources

--- a/src/components/VideoPlayerControls/VideoPlayerControlsSettingsAudioTrack.vue
+++ b/src/components/VideoPlayerControls/VideoPlayerControlsSettingsAudioTrack.vue
@@ -17,7 +17,7 @@
       class="dropdown-item-name mr-auto"
       :class="[
         this.selectedAudioSource.name === 'none' ? 'none' : '',
-        this.selectedAudioSource.sourceId === null ? this.selectedAudioSource.name : '',
+        this.selectedAudioSource.sourceId === null ? 'main' : ''
       ]"
     >
       <span

--- a/src/components/VideoPlayerSideVideoSources.vue
+++ b/src/components/VideoPlayerSideVideoSources.vue
@@ -91,7 +91,11 @@ export default {
         if (newLenght > currentLenght) {
           const lastIndex = newLenght - 1
           await projectRemoteTracks(this.sourceRemoteTracks[lastIndex])
-        } 
+        } else {
+          this.sourceRemoteTracks.forEach(async (remoteTrack) =>
+            await projectRemoteTracks(remoteTrack)
+          )
+        }
       },
     }
   },

--- a/src/components/VideoPlayerSideVideoSources.vue
+++ b/src/components/VideoPlayerSideVideoSources.vue
@@ -103,7 +103,6 @@ export default {
       await nextTick()
       this.enableClick = false
       this.playerRef = document.getElementById(this.currentElementRef)
-      const sideLabelRef = this.$refs[`sideLabel${videoMid}`][0]
 
       // Select the source from the transceiver state and project it in the main video
       let source = this.transceiverSourceState[videoMid]
@@ -111,7 +110,9 @@ export default {
       let midProjectedInMain = this.videoSources[0].mid
 
       if (this.getVideoHasMain) {
-        sideLabelRef.textContent = this.transceiverSourceState[midProjectedInMain].name        
+        if (this.viewer.showLabels) {
+          this.$refs[`sideLabel${videoMid}`][0].textContent = this.transceiverSourceState[midProjectedInMain].name        
+        }
 
         const sourceIdProjectedInMain = this.transceiverSourceState[midProjectedInMain].sourceId
         midProjectedInMain = this.transceiverSourceState[midProjectedInMain].mid

--- a/src/components/VideoPlayerSideVideoSources.vue
+++ b/src/components/VideoPlayerSideVideoSources.vue
@@ -54,7 +54,9 @@ export default {
     ...mapState('Sources', [
       'sourceRemoteTracks',
       'videoSources',
+      'audioSources',
       'transceiverSourceState',
+      'audioFollowsVideo',
     ]),
     ...mapState('Controls', {
         fullscreen: state => state.fullscreen, 
@@ -112,6 +114,8 @@ export default {
       let source = this.transceiverSourceState[videoMid]
       let lowQualityLayer
       let midProjectedInMain = this.videoSources[0].mid
+      const sourceName =  source.name
+      const audioSource = this.audioSources.find(currentSoruce => currentSoruce.name === sourceName)
 
       if (this.getVideoHasMain) {
         if (this.viewer.showLabels) {
@@ -138,6 +142,17 @@ export default {
 
       if (this.isGrid) {
         this.setIsSplittedView(false)
+      }
+
+      if ( audioSource && this.audioFollowsVideo ) {
+        try {
+          await selectSource({ kind: 'audio', source: audioSource })
+        } catch (error) {
+          this.toast.error(
+            'There was an error selecting the desired source, try again',
+            { timeout: 5000 }
+          )
+        }
       }
 
       this.enableClick = true

--- a/src/components/VideoPlayerStatsTable.vue
+++ b/src/components/VideoPlayerStatsTable.vue
@@ -168,7 +168,8 @@ export default {
       })
       this.stats = { ...this.stats, ...peerStats }
     })
-    this.selectedSourceMid = this.getTransceiverSourceState[0].mid
+    this.selectedSourceMid = this.getTransceiverSourceState[0]?.mid 
+      ?? Object.values(this.getTransceiverSourceState)[0].mid
   },
   beforeUnmount() {
     this.millicastView.webRTCPeer.stopStats()
@@ -192,7 +193,8 @@ export default {
       this.statsIndex = this.midToStatsIndexMap[mid]
     },
     selectMidZero() {
-      this.selectedSourceMid = this.getTransceiverSourceState[0].mid
+      this.selectedSourceMid = this.getTransceiverSourceState[0]?.mid 
+        ?? Object.values(this.getTransceiverSourceState)[0].mid
     },
   },
   computed: {

--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -67,9 +67,8 @@ const tracksAvailableAndMainNotExists = () => {
 }
 
 const addSource = (kind, sourceId, trackId) => {
-  const mainLabel = state.Sources.mainLabel
   const source = {
-    name: sourceId === null ? mainLabel : sourceId,
+    name: sourceId === null ? state.Params.viewer.mainLabel : sourceId,
     sourceId,
     trackId,
     mid: sourceId === null ? (kind === 'video' ? "0" : "1") : null

--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -157,19 +157,19 @@ const deleteSource = (kind, sourceId) => {
     if (state.Controls.isSplittedView) {
       if (state.Sources.selectedVideoSource.sourceId !== null && sourceId === null) {
         handleProjectVideo(state.Sources.selectedVideoSource.sourceId, `${sourceCurrentMid}`, state.Sources.selectedVideoSource.trackId)
-        if (state.viewer.showLabels) {
+        if (state.Params.viewer.showLabels) {
           document.getElementById(`sideLabel${state.Sources.selectedVideoSource.mid}`).textContent = state.Sources.selectedVideoSource.sourceId
         }
       } else if (state.Sources.selectedVideoSource.sourceId === null && sourceId !== null) {
         if (sourceCurrentMid !== sourceInitialMid) {
           handleProjectVideo(state.Sources.transceiverSourceState[sourceInitialMid].sourceId, state.Sources.transceiverSourceState[sourceCurrentMid].mid)
-          if (state.viewer.showLabels) {
+          if (state.Params.viewer.showLabels) {
             document.getElementById(`sideLabel${state.Sources.transceiverSourceState[sourceCurrentMid].mid}`).textContent = state.Sources.transceiverSourceState[sourceInitialMid].sourceId
           }
         }
       } else if (state.Sources.selectedVideoSource.sourceId !== null && sourceId !== null && sourceCurrentMid !== sourceInitialMid) {
         handleProjectVideo(state.Sources.transceiverSourceState[sourceInitialMid].sourceId, state.Sources.selectedVideoSource.mid)
-        if (state.viewer.showLabels) {
+        if (state.Params.viewer.showLabels) {
           document.getElementById(`sideLabel${state.Sources.transceiverSourceState[state.Sources.selectedVideoSource.mid].mid}`).textContent = state.Sources.transceiverSourceState[sourceInitialMid].sourceId
         }
       }

--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -158,15 +158,21 @@ const deleteSource = (kind, sourceId) => {
     if (state.Controls.isSplittedView) {
       if (state.Sources.selectedVideoSource.sourceId !== null && sourceId === null) {
         handleProjectVideo(state.Sources.selectedVideoSource.sourceId, `${sourceCurrentMid}`, state.Sources.selectedVideoSource.trackId)
-        document.getElementById(`sideLabel${state.Sources.selectedVideoSource.mid}`).textContent = state.Sources.selectedVideoSource.sourceId
+        if (state.viewer.showLabels) {
+          document.getElementById(`sideLabel${state.Sources.selectedVideoSource.mid}`).textContent = state.Sources.selectedVideoSource.sourceId
+        }
       } else if (state.Sources.selectedVideoSource.sourceId === null && sourceId !== null) {
         if (sourceCurrentMid !== sourceInitialMid) {
           handleProjectVideo(state.Sources.transceiverSourceState[sourceInitialMid].sourceId, state.Sources.transceiverSourceState[sourceCurrentMid].mid)
-          document.getElementById(`sideLabel${state.Sources.transceiverSourceState[sourceCurrentMid].mid}`).textContent = state.Sources.transceiverSourceState[sourceInitialMid].sourceId
+          if (state.viewer.showLabels) {
+            document.getElementById(`sideLabel${state.Sources.transceiverSourceState[sourceCurrentMid].mid}`).textContent = state.Sources.transceiverSourceState[sourceInitialMid].sourceId
+          }
         }
       } else if (state.Sources.selectedVideoSource.sourceId !== null && sourceId !== null && sourceCurrentMid !== sourceInitialMid) {
         handleProjectVideo(state.Sources.transceiverSourceState[sourceInitialMid].sourceId, state.Sources.selectedVideoSource.mid)
-        document.getElementById(`sideLabel${state.Sources.transceiverSourceState[state.Sources.selectedVideoSource.mid].mid}`).textContent = state.Sources.transceiverSourceState[sourceInitialMid].sourceId
+        if (state.viewer.showLabels) {
+          document.getElementById(`sideLabel${state.Sources.transceiverSourceState[state.Sources.selectedVideoSource.mid].mid}`).textContent = state.Sources.transceiverSourceState[sourceInitialMid].sourceId
+        }
       }
     }
 

--- a/src/service/viewerOptions.js
+++ b/src/service/viewerOptions.js
@@ -15,6 +15,7 @@ export const defaultViewerOptions = {
   token: null,
   forcePlayoutDelay: false,
   multisource: false,
+  audioFollowsVideo: false,
   layout: null,
   showLabels: true,
   mainLabel: null
@@ -32,6 +33,7 @@ export default function processViewerOptions({
   muted,
   noDelay,
   multisource,
+  audioFollowsVideo,
   layout,
   showLabels,
   mainLabel
@@ -48,10 +50,14 @@ export default function processViewerOptions({
   options.autoplay = autoplay ?? true
   options.muted = muted ?? false
   options.multisource = multisource ?? false
+  options.audioFollowsVideo = audioFollowsVideo ?? false
   options.layout = layout
   options.showLabels = showLabels
   if (multisource) {
     store.commit('Controls/setIsSplittedView', true)
+  }
+  if (audioFollowsVideo) {
+    store.commit('Sources/setAudioFollowsVideo', true)
   }
   if (noDelay) {
     options.forcePlayoutDelay = { min: 0, max: 0 }

--- a/src/store/modules/sources.js
+++ b/src/store/modules/sources.js
@@ -8,6 +8,7 @@ const defaulState = {
     name: 'none',
   },
   isAudioOnly: false,
+  audioFollowsVideo: false,
   stream: null,
   sourceRemoteTracks: [],
   mainLabel: 'Main',
@@ -54,6 +55,9 @@ export default {
     },
     setIsAudioOnly(state, isAudioOnly) {
       state.isAudioOnly = isAudioOnly
+    },
+    setAudioFollowsVideo(state, audioFollowsVideo) {
+      state.audioFollowsVideo = audioFollowsVideo
     },
     addSourceRemoteTrack(state, sourceRemoteTrack) {
       state.sourceRemoteTracks.push(sourceRemoteTrack)


### PR DESCRIPTION
Release of Viewer Plugin v1.2.0. The release includes:

**Added**
- Audio follows video: now, when audio follows video is enabled, and a source with audio tracks is selected, the viewer switches the audio source to the one associated with the selected video source.
- New option under `settings wheel/audio sources` for enabling (or disabling) audio-follows-video in the player.
- New `audioFollowsVideo` query parameter for enabling (or disabling) audio-follows-video in the player.
- Added the `audioFollowsVideo` option to the `README` file.

**Fixed**
- Now, when a side source connection is lost, the correct source is removed.
- Displaying the correct audio track names on the `settings wheel/audio sources` list.
- MultiView works properly when `&showLabels` is set to false.
- Media stats work as intended for Multi-source streams without a main source.