### PR TITLE
Feature/Provide clear error message when viewer fails to subscribe

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ import controls from './src/store/modules/controls'
 import layers from './src/store/modules/layers'
 import params from './src/store/modules/params'
 import sources from './src/store/modules/sources'
+import errors from './src/store/modules/errors'
 import viewConnection from './src/store/modules/viewConnection'
 
 const filterBeforeCreate = (toast, toasts) => {
@@ -26,6 +27,7 @@ export default {
     } else {
       options.store.registerModule('Controls', controls)
       options.store.registerModule('Layers', layers)
+      options.store.registerModule('Errors', errors)
       options.store.registerModule('Params', params)
       options.store.registerModule('Sources', sources)
       options.store.registerModule('ViewConnection', viewConnection)

--- a/src/components/VideoPlayerContainer.vue
+++ b/src/components/VideoPlayerContainer.vue
@@ -171,6 +171,7 @@ export default {
       viewer: (state) => state.viewer,
     }),
     ...mapState('Errors', {
+      type: (state) => state.type,
       message: (state) => state.message,
       showError: (state) => state.showError,
     }),
@@ -348,7 +349,7 @@ export default {
       })
     },
     showError: function (newVal) {
-      if (newVal) {
+      if (newVal && this.type === 'SubscriberError') {
         const toast = useToast()
         toast.error(this.message)
       } else {

--- a/src/components/VideoPlayerContainer.vue
+++ b/src/components/VideoPlayerContainer.vue
@@ -123,6 +123,7 @@ import {
   VideoPlayerControlsContainer,
 } from './VideoPlayerControls'
 import { selectSource } from '../service/sdkManager'
+import { useToast } from 'vue-toastification'
 
 export default {
   name: 'VideoPlayerContainer',
@@ -169,6 +170,10 @@ export default {
     ...mapState('Params', {
       viewer: (state) => state.viewer,
     }),
+    ...mapState('Errors', {
+      message: (state) => state.message,
+      showError: (state) => state.showError,
+    }),
     ...mapState('Sources', {
       videoSources: (state) => state.videoSources,
       audioSources: (state) => state.audioSources,
@@ -204,6 +209,7 @@ export default {
   },
   methods: {
     ...mapMutations('Layers', ['deleteLayers']),
+    ...mapMutations('Errors', ['setShowError']),
     ...mapMutations('Sources', ['deleteSource', 'setMainLabel']),
     ...mapMutations('Controls', [
       'setVideo',
@@ -340,6 +346,14 @@ export default {
         token: this.viewer.token,
         loading: this.isLoading,
       })
+    },
+    showError: function (newVal) {
+      if (newVal) {
+        const toast = useToast()
+        toast.error(this.message)
+      } else {
+        this.setShowError(false)
+      }
     },
   },
 }

--- a/src/service/utils/viewConnection.js
+++ b/src/service/utils/viewConnection.js
@@ -54,8 +54,9 @@ export const handleInitViewConnection = (accountId, streamName) => {
       subscriber.catch((error) => {
         const errorMessage = `${error}`
         const splitedMessage = errorMessage.replace('FetchError: ','')
-        store.commit('Errors/setMessage', splitedMessage)
-        store.commit('Errors/setShowError', true)
+        commit('Errors/setMessage', splitedMessage)
+        commit('Errors/setType', 'SubscriberError')
+        commit('Errors/setShowError', true)
       })
       return subscriber
   }

--- a/src/service/utils/viewConnection.js
+++ b/src/service/utils/viewConnection.js
@@ -45,12 +45,21 @@ export const handleInitViewConnection = (accountId, streamName) => {
     throw new Error('Stream ID not provided.')
   }
   setEnvironment()
-  const tokenGenerator = () =>
-    Director.getSubscriber(
-      streamName,
-      accountId,
-      state.Params.viewer.token
-    )
+  const tokenGenerator = () => {
+      const subscriber = Director.getSubscriber(
+        streamName,
+        accountId,
+        state.Params.viewer.token
+      )
+      subscriber.catch((error) => {
+        const errorMessage = `${error}`
+        const splitedMessage = errorMessage.replace('FetchError: ','')
+        store.commit('Errors/setMessage', splitedMessage)
+        store.commit('Errors/setShowError', true)
+      })
+      return subscriber
+  }
+
   const millicastView = new View(streamName, tokenGenerator)
   window.millicastView = millicastView
   window.__defineGetter__('peer', () => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,6 +5,7 @@ import Layers from './modules/layers'
 import Controls from './modules/controls'
 import ViewConnection from './modules/viewConnection'
 import Params from './modules/params'
+import Errors from './modules/errors'
 
 export default createStore({
   state: {
@@ -18,5 +19,6 @@ export default createStore({
     Controls,
     ViewConnection,
     Params,
+    Errors,
   },
 })

--- a/src/store/modules/errors.js
+++ b/src/store/modules/errors.js
@@ -1,0 +1,17 @@
+const defaulState = {
+  message: '',
+  showError: false,
+}
+
+export default {
+  namespaced: true,
+  state: defaulState,
+  mutations: {
+    setMessage(state, message) {
+      state.message = message
+    },
+    setShowError(state, show) {
+      state.showError = show
+    },
+  },
+}

--- a/src/store/modules/errors.js
+++ b/src/store/modules/errors.js
@@ -1,14 +1,18 @@
-const defaulState = {
+const defaultState = {
+  type: '',
   message: '',
   showError: false,
 }
 
 export default {
   namespaced: true,
-  state: defaulState,
+  state: defaultState,
   mutations: {
     setMessage(state, message) {
       state.message = message
+    },
+    setType(state, type) {
+      state.type = type
     },
     setShowError(state, show) {
       state.showError = show


### PR DESCRIPTION
Added UX improvements at the moment the user fails to subscribe to the token. Whenever the following situations happen, we display an error message:
- Use case 1:  Viewer failed to view the stream due to Geo-blocking setting
- Use case 2: Viewer failed to view the stream due to missing subscribe token for the publishing token enable secure.