### PR TITLE
Fix/Firefox stats not showing all values

### DIFF
--- a/src/components/VideoPlayerStatsTable.vue
+++ b/src/components/VideoPlayerStatsTable.vue
@@ -149,15 +149,17 @@ export default {
       stats: {},
       statsIndex: 0,
       selectedSourceMid: null,
-      midToStatsIndexMap: {},
+      trackIdToStatsIndexMap: {},
+      trackIdMidMap: {}
     }
   },
   mounted() {
     this.millicastView.webRTCPeer.initStats()
     this.millicastView.webRTCPeer.on('stats', (peerStats) => {
+      this.trackIdMidMap = this.getTrackIdMidMap
       peerStats.video?.inbounds?.forEach((stat, index) => {
-        if (stat.mid) {
-          this.midToStatsIndexMap[stat.mid] = index
+        if (stat.trackIdentifier) {
+          this.trackIdToStatsIndexMap[stat.trackIdentifier] = index
         }
       })
       window.peer?.getReceivers?.().forEach?.((receiver) => {
@@ -190,7 +192,7 @@ export default {
     },
     handleSourceChange() {
       const mid = this.selectedSourceMid ?? 0
-      this.statsIndex = this.midToStatsIndexMap[mid]
+      this.statsIndex = this.trackIdToStatsIndexMap[this.trackIdMidMap[mid]]
     },
     selectMidZero() {
       this.selectedSourceMid = this.getTransceiverSourceState[0]?.mid 
@@ -210,7 +212,8 @@ export default {
       'videoSources'
     ]),
     ...mapGetters('Sources', [
-      'getTransceiverSourceState'
+      'getTransceiverSourceState',
+      'getTrackIdMidMap'
     ]),
     hasStats() {
       return Object.keys(this.stats).length > 0
@@ -226,7 +229,7 @@ export default {
       const video = this.stats.video?.inbounds
       const videoLength = video?.length
       if (videoLength) {
-        return video[this.midToStatsIndexMap[this.selectedSourceMid]]
+        return video[this.trackIdToStatsIndexMap[this.trackIdMidMap[this.selectedSourceMid]]]
       }
       return null
     },
@@ -282,7 +285,7 @@ export default {
       const multiviewIsOn = (
         this.videoSources.length > 1 && 
         this.isSplittedView && 
-        Object.keys(this.midToStatsIndexMap).length
+        Object.keys(this.trackIdToStatsIndexMap).length
       )
       if (!multiviewIsOn) {
         this.selectMidZero()

--- a/src/service/utils/viewConnection.js
+++ b/src/service/utils/viewConnection.js
@@ -90,6 +90,13 @@ export const handleConnectToStream = async () => {
 export const setTrackEvent = () => {
   const millicastView = state.ViewConnection.millicastView
   millicastView.on('track', async (event) => {
+    // map video trackId with mid
+    if (event.track?.kind === 'video') {
+      commit('Sources/addTrackIdMidMapping', {
+        trackId: event.track?.id,
+        mid: event.transceiver?.mid
+      })
+    }
     if (event.streams.length) {
       await setStream(event.streams[0])
     }

--- a/src/store/modules/sources.js
+++ b/src/store/modules/sources.js
@@ -13,6 +13,7 @@ const defaulState = {
   sourceRemoteTracks: [],
   mainLabel: 'Main',
   transceiverSourceState: {},
+  trackIdMidMap: {}
 }
 
 export default {
@@ -58,6 +59,9 @@ export default {
     },
     setAudioFollowsVideo(state, audioFollowsVideo) {
       state.audioFollowsVideo = audioFollowsVideo
+    },
+    addTrackIdMidMapping(state, trackIdMidMapping) {
+      state.trackIdMidMap[trackIdMidMapping.mid] = trackIdMidMapping.trackId
     },
     addSourceRemoteTrack(state, sourceRemoteTrack) {
       state.sourceRemoteTracks.push(sourceRemoteTrack)
@@ -155,6 +159,9 @@ export default {
     },
     getTransceiverSourceState(state) {
       return state.transceiverSourceState
+    },
+    getTrackIdMidMap(state) {
+      return state.trackIdMidMap
     }
   },
 }


### PR DESCRIPTION
Change the way values are parsed when stats event is called. Before, stats used `mid` value to select which stats to show. Now it is based on the `trackIdentifier` of the stats event's payload, that is available in all browsers.

On Firefox, when viewing the Media Stats, it should be shown video stats that previously were not shown.

This fix depends on a change from the Millicast SDK.