### PR TITLE
fix/Reconnecting in a simulcast stream doesn't update the layer

### DIFF
--- a/src/components/VideoPlayerSideVideoSources.vue
+++ b/src/components/VideoPlayerSideVideoSources.vue
@@ -216,6 +216,7 @@ li {
 
 .list-side {
   margin: auto;
+  width: 100%;
 }
 
 .list-item {

--- a/src/service/utils/layers.js
+++ b/src/service/utils/layers.js
@@ -64,7 +64,7 @@ export const updateLayers = (evntData) => {
     return b.bitrate - a.bitrate
   })
   if (activeQualities.length >= 2) {
-    activeQualities.sort((layer, nextLayer) =>  nextLayer.id - layer.id ) 
+    activeQualities.sort((quality, nextQuality) =>  nextQuality.height - quality.height ) 
     const names = qualityNames[activeQualities.length] || []
     activeQualities.forEach((quality, index) => {
       quality.name = quality.height ? `${quality.height}p` : names[index] || formatBitsRecursive(quality.bitrate)

--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -108,6 +108,10 @@ const processTrackWarning = () => {
 }
 
 export const handleDeleteSource = (sourceId) => {
+  if (state.Layers.mainTransceiverMedias.active.length) {
+    // If stream has simulcast enabled, set the source quality to auto before droping the source
+    layers.handleSelectQuality({name: 'Auto'})
+  }
   const videoIndex = state.Sources.videoSources.findIndex(
     (source) => source.sourceId === sourceId
   )


### PR DESCRIPTION
Steps to reproduce:
- Start watching a simulcast stream
- Choose a layer different than auto (let's say 240p)
- Disconnect publisher
- Reconnect publisher
- Viewer is still watching the 240p layer, but the menu shows "Auto" as chosen layer
