### PR TITLE
Feature / Add startingQuality query param for layer selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can now use the plugin in any Vue file of your project as a component.
 | `showLabels`   | `Boolean`        | Optional  | `true`              | Show stream label in multiview mode.                                                                 |
 | `environment`  | `Object`         | Optional  | `.env file content` | Plugin environment. See [Environment options](#environment-options) on how to configure.             |
 | `mainLabel`    | `String`         | Optional  |                     | Allows to change the label of the main video.                                                        |
-| `startingQuality` | `String/Number` | Optional | Allows to start the stream at a specific resolution when available. |
+| `startingQuality` | `String` | Optional | Allows to start the stream at a specific resolution when available. Possible values: 'High', 'Medium', 'Low', <Number> specifying the desired frame height (i.e. 360). |
 | `audioFollowsVideo`| `Boolean`    | Optional  | `false`             | Allows automatically switching the audio to the one associated with the selected video source.       |
 
 To be able to use the viewer, just reference the `VideoPlayer` component, and pass the parameters of your choice as an object in the parameter `paramsOptions`. Refer to the [example usage](#example-apps).

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can now use the plugin in any Vue file of your project as a component.
 | `showLabels`   | `Boolean`        | Optional  | `true`              | Show stream label in multiview mode.                                                                 |
 | `environment`  | `Object`         | Optional  | `.env file content` | Plugin environment. See [Environment options](#environment-options) on how to configure.             |
 | `mainLabel`    | `String`         | Optional  |                     | Allows to change the label of the main video.                                                        |
+| `startingQuality` | `String/Number` | Optional | Allows to start the stream at a specific resolution when available. |
 | `audioFollowsVideo`| `Boolean`    | Optional  | `false`             | Allows automatically switching the audio to the one associated with the selected video source.       |
 
 To be able to use the viewer, just reference the `VideoPlayer` component, and pass the parameters of your choice as an object in the parameter `paramsOptions`. Refer to the [example usage](#example-apps).

--- a/src/App.vue
+++ b/src/App.vue
@@ -52,6 +52,7 @@ export default {
           audioFollowsVideo: this.paramsOptions?.audioFollowsVideo ?? false,
           layout: this.paramsOptions?.layout ?? null,
           showLabels: this.paramsOptions?.showLabels ?? true,
+          startingQuality: this.paramsOptions?.startingQuality,
           mainLabel: this.paramsOptions?.mainLabel ?? 'Main'
         })
       }
@@ -66,6 +67,11 @@ export default {
       containerClassName: 'toast-custom',
     })
     this.updateParams()
+
+    // Starting quality toast
+    if (this.paramsOptions?.startingQuality) {
+      toast.info('Fetching starting quality layer', { timeout: 1500 })
+    }
 
     ElementQueries.listen()
     ElementQueries.init()

--- a/src/service/sdkManager.js
+++ b/src/service/sdkManager.js
@@ -183,14 +183,14 @@ const updateLayersBroadcastState = (event) => {
     if (/^\d{3,4}$/.test(startingQuality)) {
       // Select layer with specific height
       selectedMedia = medias.find((media) => media.height === parseInt(startingQuality))
-      console.log('Selected media, height:', selectedMedia)
+      console.log('Selected media, height:', selectedMedia.id)
     } else if (qualityIndex >= 0) {
       if (startingQuality.toLowerCase() === 'low') {
         selectedMedia = medias[medias.length - 1]
       } else {
         selectedMedia = medias[qualityIndex]
       }
-      console.log('Selected media, level:', selectedMedia)
+      console.log('Selected media, level:', selectedMedia.id)
     } else {
       console.warn('Not valid starting quality, switching to Auto')
       selectedMedia = { name: 'Auto' }

--- a/src/service/sdkManager.js
+++ b/src/service/sdkManager.js
@@ -169,7 +169,9 @@ const updateLayersBroadcastState = (event) => {
   const medias = state.Layers.mainTransceiverMedias.active
   if (medias.length === 0) {
     console.warn('No active layers available, will wait for next event. Switching to Auto until then.')
-    selectingLayerTimeout != null && clearTimeout(selectingLayerTimeout)
+    if (selectingLayerTimeout != null) {
+      clearTimeout(selectingLayerTimeout)
+    }
     selectingLayerTimeout = null
     commit('Controls/setIsLoading', false)
     return
@@ -199,7 +201,9 @@ const updateLayersBroadcastState = (event) => {
     }
     setTimeout(() => {
       selectQuality(selectedMedia)
-      selectingLayerTimeout != null && clearTimeout(selectingLayerTimeout)
+      if (selectingLayerTimeout != null) {
+        clearTimeout(selectingLayerTimeout)
+      }
       selectingLayerTimeout = null
       commit('Controls/setIsSelectingLayer', false)
       commit('Controls/setIsLoading', false)

--- a/src/service/viewerOptions.js
+++ b/src/service/viewerOptions.js
@@ -18,6 +18,7 @@ export const defaultViewerOptions = {
   audioFollowsVideo: false,
   layout: null,
   showLabels: true,
+  startingQuality: null,
   mainLabel: null
 }
 
@@ -36,6 +37,7 @@ export default function processViewerOptions({
   audioFollowsVideo,
   layout,
   showLabels,
+  startingQuality,
   mainLabel
 }) {
   const options = {}
@@ -65,7 +67,10 @@ export default function processViewerOptions({
   if (options.layout && options.layout === 'grid') {
     store.commit('Controls/setIsGrid', true)
   }
-
+  if (startingQuality !== null) {
+    options.startingQuality = startingQuality
+    store.commit('Controls/setIsSelectingLayer', true)
+  }
   if (mainLabel) {
     options.mainLabel = mainLabel
     store.commit('Sources/setMainLabel', options.mainLabel)

--- a/src/store/modules/controls.js
+++ b/src/store/modules/controls.js
@@ -25,7 +25,9 @@ const defaulState = {
   migrateListenerIsSet: false,
   isSplittedView: false,
   previousSplitState: false,
-  isGrid: false
+  isGrid: false,
+  isSelectingLayer: false,
+  selectingLayerTimeouts: null
 }
 
 export default {
@@ -138,6 +140,12 @@ export default {
     },
     setIsGrid(state, isGrid) {
       state.isGrid = isGrid
+    },
+    setIsSelectingLayer(state, isSelectingLayer) {
+      state.isSelectingLayer = isSelectingLayer
+    },
+    setSelectingLayerTimeout(state, selectingLayerTimeout) {
+      state.selectingLayerTimeouts = selectingLayerTimeout
     }
   },
   getters: {},


### PR DESCRIPTION
Added in the paramOptions a new option called `startingQuality` which will set the layer specified, if any available (simulcast stream). There are 2 formats accepted:

1. Category of quality: posible values are **High**, **Medium** or **Low**.
2. Height of the video: a numerical value with a maximum length of 4 representing the desired height of the video. This value will be mapped to the corresponding height layer. If the entered value is invalid or does not match the height of any available layers, a warning will be logged. In such cases, the Auto quality setting will be automatically selected.