### PR TITLE
Fix/Stream no being published toast appears

### DIFF
--- a/src/service/utils/viewConnection.js
+++ b/src/service/utils/viewConnection.js
@@ -53,10 +53,12 @@ export const handleInitViewConnection = (accountId, streamName) => {
       )
       subscriber.catch((error) => {
         const errorMessage = `${error}`
-        const splitedMessage = errorMessage.replace('FetchError: ','')
-        commit('Errors/setMessage', splitedMessage)
-        commit('Errors/setType', 'SubscriberError')
-        commit('Errors/setShowError', true)
+        if(!errorMessage.includes('stream not being published')) {
+          const splitedMessage = errorMessage.replace('FetchError: ','')
+          commit('Errors/setMessage', splitedMessage)
+          commit('Errors/setType', 'SubscriberError')
+          commit('Errors/setShowError', true)
+        }
       })
       return subscriber
   }


### PR DESCRIPTION
## Description/Steps-to-reproduce:
Open the viewer in one tab.
Open the broadcaster on another.
Refresh the viewer.
Go back to the broadcaster and start a stream.
Step three and four should be done very fast.

## Expected result:
Toast does not appear.
