### PR TITLE
v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@millicast/vue-viewer-plugin",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "license": "See in LICENSE file",
             "dependencies": {
                 "@millicast/sdk": "^0.1.43",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "private": false,
     "author": "Millicast, Inc.",
     "scripts": {


### PR DESCRIPTION
**Added**
- Provide clear error message when viewer fails to subscribe the stream.
- `startingQuality` query param, allowing the hosted player to start at a specific layer when connecting to a simulcast stream.

**Fixed**
- Consistency in media stats between browsers.
- Now displays multisource source correctly when using Multi source SRT stream.
- Now, reconnecting to a simulcast stream updates the layer correctly to `auto`.