### PR TITLE
v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can now use the plugin in any Vue file of your project as a component.
 | `showLabels`   | `Boolean`        | Optional  | `true`              | Show stream label in multiview mode.                                                                 |
 | `environment`  | `Object`         | Optional  | `.env file content` | Plugin environment. See [Environment options](#environment-options) on how to configure.             |
 | `mainLabel`    | `String`         | Optional  |                     | Allows to change the label of the main video.                                                        |
+| `audioFollowsVideo`| `Boolean`    | Optional  | `false`             | Allows automatically switching the audio to the one associated with the selected video source.       |
 
 To be able to use the viewer, just reference the `VideoPlayer` component, and pass the parameters of your choice as an object in the parameter `paramsOptions`. Refer to the [example usage](#example-apps).
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can now use the plugin in any Vue file of your project as a component.
 | `showLabels`   | `Boolean`        | Optional  | `true`              | Show stream label in multiview mode.                                                                 |
 | `environment`  | `Object`         | Optional  | `.env file content` | Plugin environment. See [Environment options](#environment-options) on how to configure.             |
 | `mainLabel`    | `String`         | Optional  |                     | Allows to change the label of the main video.                                                        |
+| `startingQuality` | `String` | Optional | Allows to start the stream at a specific resolution when available. Possible values: 'High', 'Medium', 'Low', <Number> specifying the desired frame height (i.e. 360). |
 | `audioFollowsVideo`| `Boolean`    | Optional  | `false`             | Allows automatically switching the audio to the one associated with the selected video source.       |
 
 To be able to use the viewer, just reference the `VideoPlayer` component, and pass the parameters of your choice as an object in the parameter `paramsOptions`. Refer to the [example usage](#example-apps).

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ import controls from './src/store/modules/controls'
 import layers from './src/store/modules/layers'
 import params from './src/store/modules/params'
 import sources from './src/store/modules/sources'
+import errors from './src/store/modules/errors'
 import viewConnection from './src/store/modules/viewConnection'
 
 const filterBeforeCreate = (toast, toasts) => {
@@ -26,6 +27,7 @@ export default {
     } else {
       options.store.registerModule('Controls', controls)
       options.store.registerModule('Layers', layers)
+      options.store.registerModule('Errors', errors)
       options.store.registerModule('Params', params)
       options.store.registerModule('Sources', sources)
       options.store.registerModule('ViewConnection', viewConnection)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.2.0",
             "license": "See in LICENSE file",
             "dependencies": {
-                "@millicast/sdk": "^0.1.41",
+                "@millicast/sdk": "^0.1.43",
                 "bootstrap": "github:millicast/bootstrap#ml-viewer",
                 "bootstrap-icons": "github:millicast/icons#ml-viewer",
                 "can-autoplay": "^3.0.0",
@@ -1781,9 +1781,9 @@
             }
         },
         "node_modules/@millicast/sdk": {
-            "version": "0.1.41",
-            "resolved": "https://registry.npmjs.org/@millicast/sdk/-/sdk-0.1.41.tgz",
-            "integrity": "sha512-j8uedLif28Nm6jGXUdKC87McuKR+ag+xhq3MxJooKg/HYmrL90aJVFhtrYkTuLZn3W4YiCnpOIy+TK6YzIR3Ig==",
+            "version": "0.1.43",
+            "resolved": "https://registry.npmjs.org/@millicast/sdk/-/sdk-0.1.43.tgz",
+            "integrity": "sha512-LGOWYrmV1Xh5iD++bMBMdD19fOND/l7cJsbCJW6ruoE7YNQyKi6yT3ayzDI+NLfvmPvXKkOaDjqWUDdd7BjsSA==",
             "dependencies": {
                 "@types/node": "^18.11.10",
                 "Base64": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@millicast/vue-viewer-plugin",
-            "version": "1.1.3",
+            "version": "1.2.0",
             "license": "See in LICENSE file",
             "dependencies": {
                 "@millicast/sdk": "^0.1.41",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@millicast/vue-viewer-plugin",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "license": "See in LICENSE file",
             "dependencies": {
                 "@millicast/sdk": "^0.1.43",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "private": false,
     "author": "Millicast, Inc.",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "private": false,
     "author": "Millicast, Inc.",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "README.md"
     ],
     "dependencies": {
-        "@millicast/sdk": "^0.1.41",
+        "@millicast/sdk": "^0.1.43",
         "bootstrap": "github:millicast/bootstrap#ml-viewer",
         "bootstrap-icons": "github:millicast/icons#ml-viewer",
         "can-autoplay": "^3.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -52,6 +52,7 @@ export default {
           audioFollowsVideo: this.paramsOptions?.audioFollowsVideo ?? false,
           layout: this.paramsOptions?.layout ?? null,
           showLabels: this.paramsOptions?.showLabels ?? true,
+          startingQuality: this.paramsOptions?.startingQuality,
           mainLabel: this.paramsOptions?.mainLabel ?? 'Main'
         })
       }
@@ -66,6 +67,11 @@ export default {
       containerClassName: 'toast-custom',
     })
     this.updateParams()
+
+    // Starting quality toast
+    if (this.paramsOptions?.startingQuality) {
+      toast.info('Fetching starting quality layer', { timeout: 1500 })
+    }
 
     ElementQueries.listen()
     ElementQueries.init()

--- a/src/components/VideoPlayerContainer.vue
+++ b/src/components/VideoPlayerContainer.vue
@@ -123,6 +123,7 @@ import {
   VideoPlayerControlsContainer,
 } from './VideoPlayerControls'
 import { selectSource } from '../service/sdkManager'
+import { useToast } from 'vue-toastification'
 
 export default {
   name: 'VideoPlayerContainer',
@@ -169,6 +170,11 @@ export default {
     ...mapState('Params', {
       viewer: (state) => state.viewer,
     }),
+    ...mapState('Errors', {
+      type: (state) => state.type,
+      message: (state) => state.message,
+      showError: (state) => state.showError,
+    }),
     ...mapState('Sources', {
       videoSources: (state) => state.videoSources,
       audioSources: (state) => state.audioSources,
@@ -204,6 +210,7 @@ export default {
   },
   methods: {
     ...mapMutations('Layers', ['deleteLayers']),
+    ...mapMutations('Errors', ['setShowError']),
     ...mapMutations('Sources', ['deleteSource', 'setMainLabel']),
     ...mapMutations('Controls', [
       'setVideo',
@@ -340,6 +347,14 @@ export default {
         token: this.viewer.token,
         loading: this.isLoading,
       })
+    },
+    showError: function (newVal) {
+      if (newVal && this.type === 'SubscriberError') {
+        const toast = useToast()
+        toast.error(this.message)
+      } else {
+        this.setShowError(false)
+      }
     },
   },
 }

--- a/src/components/VideoPlayerSideVideoSources.vue
+++ b/src/components/VideoPlayerSideVideoSources.vue
@@ -216,6 +216,7 @@ li {
 
 .list-side {
   margin: auto;
+  width: 100%;
 }
 
 .list-item {

--- a/src/service/utils/layers.js
+++ b/src/service/utils/layers.js
@@ -64,7 +64,7 @@ export const updateLayers = (evntData) => {
     return b.bitrate - a.bitrate
   })
   if (activeQualities.length >= 2) {
-    activeQualities.sort((layer, nextLayer) =>  nextLayer.id - layer.id ) 
+    activeQualities.sort((quality, nextQuality) =>  nextQuality.height - quality.height ) 
     const names = qualityNames[activeQualities.length] || []
     activeQualities.forEach((quality, index) => {
       quality.name = quality.height ? `${quality.height}p` : names[index] || formatBitsRecursive(quality.bitrate)

--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -108,6 +108,10 @@ const processTrackWarning = () => {
 }
 
 export const handleDeleteSource = (sourceId) => {
+  if (state.Layers.mainTransceiverMedias.active.length) {
+    // If stream has simulcast enabled, set the source quality to auto before droping the source
+    layers.handleSelectQuality({name: 'Auto'})
+  }
   const videoIndex = state.Sources.videoSources.findIndex(
     (source) => source.sourceId === sourceId
   )

--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -180,6 +180,7 @@ const deleteSource = (kind, sourceId) => {
     }
 
     commit('Sources/removeTransceiverSourceState', sourceId)
+    commit('Sources/removeTrackIdMidMapping', sourceCurrentMid)
   }
 
   commit('Sources/removeSourceRemoteTrack', sourceId)

--- a/src/service/utils/viewConnection.js
+++ b/src/service/utils/viewConnection.js
@@ -102,6 +102,13 @@ export const handleConnectToStream = async () => {
 export const setTrackEvent = () => {
   const millicastView = state.ViewConnection.millicastView
   millicastView.on('track', async (event) => {
+    // map video trackId with mid
+    if (event.track?.kind === 'video') {
+      commit('Sources/addTrackIdMidMapping', {
+        trackId: event.track?.id,
+        mid: event.transceiver?.mid
+      })
+    }
     if (event.streams.length) {
       await setStream(event.streams[0])
     }

--- a/src/service/utils/viewConnection.js
+++ b/src/service/utils/viewConnection.js
@@ -53,10 +53,12 @@ export const handleInitViewConnection = (accountId, streamName) => {
       )
       subscriber.catch((error) => {
         const errorMessage = `${error}`
-        const splitedMessage = errorMessage.replace('FetchError: ','')
-        commit('Errors/setMessage', splitedMessage)
-        commit('Errors/setType', 'SubscriberError')
-        commit('Errors/setShowError', true)
+        if(!errorMessage.includes('stream not being published')) {
+          const splitedMessage = errorMessage.replace('FetchError: ','')
+          commit('Errors/setMessage', splitedMessage)
+          commit('Errors/setType', 'SubscriberError')
+          commit('Errors/setShowError', true)
+        }
       })
       return subscriber
   }

--- a/src/service/utils/viewConnection.js
+++ b/src/service/utils/viewConnection.js
@@ -45,12 +45,22 @@ export const handleInitViewConnection = (accountId, streamName) => {
     throw new Error('Stream ID not provided.')
   }
   setEnvironment()
-  const tokenGenerator = () =>
-    Director.getSubscriber(
-      streamName,
-      accountId,
-      state.Params.viewer.token
-    )
+  const tokenGenerator = () => {
+      const subscriber = Director.getSubscriber(
+        streamName,
+        accountId,
+        state.Params.viewer.token
+      )
+      subscriber.catch((error) => {
+        const errorMessage = `${error}`
+        const splitedMessage = errorMessage.replace('FetchError: ','')
+        commit('Errors/setMessage', splitedMessage)
+        commit('Errors/setType', 'SubscriberError')
+        commit('Errors/setShowError', true)
+      })
+      return subscriber
+  }
+
   const millicastView = new View(streamName, tokenGenerator)
   window.millicastView = millicastView
   window.__defineGetter__('peer', () => {

--- a/src/service/viewerOptions.js
+++ b/src/service/viewerOptions.js
@@ -18,6 +18,7 @@ export const defaultViewerOptions = {
   audioFollowsVideo: false,
   layout: null,
   showLabels: true,
+  startingQuality: null,
   mainLabel: null
 }
 
@@ -36,6 +37,7 @@ export default function processViewerOptions({
   audioFollowsVideo,
   layout,
   showLabels,
+  startingQuality,
   mainLabel
 }) {
   const options = {}
@@ -65,7 +67,10 @@ export default function processViewerOptions({
   if (options.layout && options.layout === 'grid') {
     store.commit('Controls/setIsGrid', true)
   }
-
+  if (startingQuality !== null) {
+    options.startingQuality = startingQuality
+    store.commit('Controls/setIsSelectingLayer', true)
+  }
   if (mainLabel) {
     options.mainLabel = mainLabel
     store.commit('Sources/setMainLabel', options.mainLabel)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,6 +5,7 @@ import Layers from './modules/layers'
 import Controls from './modules/controls'
 import ViewConnection from './modules/viewConnection'
 import Params from './modules/params'
+import Errors from './modules/errors'
 
 export default createStore({
   state: {
@@ -18,5 +19,6 @@ export default createStore({
     Controls,
     ViewConnection,
     Params,
+    Errors,
   },
 })

--- a/src/store/modules/controls.js
+++ b/src/store/modules/controls.js
@@ -25,7 +25,9 @@ const defaulState = {
   migrateListenerIsSet: false,
   isSplittedView: false,
   previousSplitState: false,
-  isGrid: false
+  isGrid: false,
+  isSelectingLayer: false,
+  selectingLayerTimeouts: null
 }
 
 export default {
@@ -138,6 +140,12 @@ export default {
     },
     setIsGrid(state, isGrid) {
       state.isGrid = isGrid
+    },
+    setIsSelectingLayer(state, isSelectingLayer) {
+      state.isSelectingLayer = isSelectingLayer
+    },
+    setSelectingLayerTimeout(state, selectingLayerTimeout) {
+      state.selectingLayerTimeouts = selectingLayerTimeout
     }
   },
   getters: {},

--- a/src/store/modules/errors.js
+++ b/src/store/modules/errors.js
@@ -1,0 +1,21 @@
+const defaultState = {
+  type: '',
+  message: '',
+  showError: false,
+}
+
+export default {
+  namespaced: true,
+  state: defaultState,
+  mutations: {
+    setMessage(state, message) {
+      state.message = message
+    },
+    setType(state, type) {
+      state.type = type
+    },
+    setShowError(state, show) {
+      state.showError = show
+    },
+  },
+}

--- a/src/store/modules/sources.js
+++ b/src/store/modules/sources.js
@@ -13,6 +13,7 @@ const defaulState = {
   sourceRemoteTracks: [],
   mainLabel: 'Main',
   transceiverSourceState: {},
+  trackIdMidMap: {}
 }
 
 export default {
@@ -58,6 +59,9 @@ export default {
     },
     setAudioFollowsVideo(state, audioFollowsVideo) {
       state.audioFollowsVideo = audioFollowsVideo
+    },
+    addTrackIdMidMapping(state, trackIdMidMapping) {
+      state.trackIdMidMap[trackIdMidMapping.mid] = trackIdMidMapping.trackId
     },
     addSourceRemoteTrack(state, sourceRemoteTrack) {
       state.sourceRemoteTracks.push(sourceRemoteTrack)
@@ -117,6 +121,9 @@ export default {
         }
       }
     },
+    removeTrackIdMidMapping(state, mid) {
+      delete state.trackIdMidMap[mid]
+    },
     setMainLabel(state, label) {
       state.mainLabel = label
     },
@@ -155,6 +162,9 @@ export default {
     },
     getTransceiverSourceState(state) {
       return state.transceiverSourceState
+    },
+    getTrackIdMidMap(state) {
+      return state.trackIdMidMap
     }
   },
 }


### PR DESCRIPTION
**Added**
- Provide clear error message when viewer fails to subscribe the stream.
- `startingQuality` query param, allowing the hosted player to start at a specific layer when connecting to a simulcast stream.

**Fixed**
- Consistency in media stats between browsers.
- Now displays multisource source correctly when using Multi source SRT stream.
- Now, reconnecting to a simulcast stream updates the layer correctly to `auto`.