### PR TITLE
v1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@millicast/vue-viewer-plugin",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "license": "See in LICENSE file",
             "dependencies": {
                 "@millicast/sdk": "^0.1.43",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "private": false,
     "author": "Millicast, Inc.",
     "scripts": {


### PR DESCRIPTION
Release of Viewer Plugin v1.4.0. The release includes:

**Added**
- New option parameter called `hideToast` which allows hiding a specific type of toast notification. To hide multiple toast types, separate them using `,`. Possible values: `success`, `error`, `warning`, `info`.