### PR TITLE
v1.4.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ You can now use the plugin in any Vue file of your project as a component.
 | `showLabels`   | `Boolean`        | Optional  | `true`              | Show stream label in multiview mode.                                                                 |
 | `environment`  | `Object`         | Optional  | `.env file content` | Plugin environment. See [Environment options](#environment-options) on how to configure.             |
 | `mainLabel`    | `String`         | Optional  |                     | Allows to change the label of the main video.                                                        |
-| `startingQuality` | `String` | Optional | Allows to start the stream at a specific resolution when available. Possible values: 'High', 'Medium', 'Low', <Number> specifying the desired frame height (i.e. 360). |
+| `startingQuality` | `String` | Optional | `null`| Allows to start the stream at a specific resolution when available. Possible values: 'High', 'Medium', 'Low', <Number> specifying the desired frame height (i.e. 360). |
+| `hideToast`   | `String`          | Optional |  `null`              | Allows to hide a specific type of toast notification. To hide multiple toast types, separate them using `,`. Possible values: `success`, `error`, `warning`, `info`. |
 | `audioFollowsVideo`| `Boolean`    | Optional  | `false`             | Allows automatically switching the audio to the one associated with the selected video source.       |
 
 To be able to use the viewer, just reference the `VideoPlayer` component, and pass the parameters of your choice as an object in the parameter `paramsOptions`. Refer to the [example usage](#example-apps).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@millicast/vue-viewer-plugin",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "license": "See in LICENSE file",
             "dependencies": {
                 "@millicast/sdk": "^0.1.43",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "private": false,
     "author": "Millicast, Inc.",
     "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
 
 <script>
 import VideoPlayerContainer from './components/VideoPlayerContainer.vue'
-import { useToast } from 'vue-toastification'
+import CustomToast from './service/utils/toast'
 import processViewerOptions from './service/viewerOptions'
 import { availableControls } from './service/viewerOptions'
 import processEnvironmentOptions from './service/environmentOptions'
@@ -53,6 +53,7 @@ export default {
           layout: this.paramsOptions?.layout ?? null,
           showLabels: this.paramsOptions?.showLabels ?? true,
           startingQuality: this.paramsOptions?.startingQuality,
+          hideToast: this.paramsOptions?.hideToast,
           mainLabel: this.paramsOptions?.mainLabel ?? 'Main'
         })
       }
@@ -61,7 +62,7 @@ export default {
   },
   async mounted() {
     const myContainer = document.getElementById('viewer-container')
-    const toast = await useToast()
+    const toast = await new CustomToast()
     toast.updateDefaults({
       container: myContainer,
       containerClassName: 'toast-custom',
@@ -70,7 +71,7 @@ export default {
 
     // Starting quality toast
     if (this.paramsOptions?.startingQuality) {
-      toast.info('Fetching starting quality layer', { timeout: 1500 })
+      toast.showToast('info','Fetching starting quality layer', { timeout: 1500 })
     }
 
     ElementQueries.listen()

--- a/src/components/VideoPlayerContainer.vue
+++ b/src/components/VideoPlayerContainer.vue
@@ -123,7 +123,7 @@ import {
   VideoPlayerControlsContainer,
 } from './VideoPlayerControls'
 import { selectSource } from '../service/sdkManager'
-import { useToast } from 'vue-toastification'
+import CustomToast from '../service/utils/toast'
 
 export default {
   name: 'VideoPlayerContainer',
@@ -142,6 +142,7 @@ export default {
       cast: { isConnected: false },
       controlsTimeout: 0,
       mobileFullscreen: false,
+      toast: new CustomToast(),
     }
   },
   mounted() {
@@ -197,6 +198,7 @@ export default {
       autoPlayMuted: (state) => state.autoPlayMuted,
       isLive: (state) => state.isLive,
       isSplittedView: (state) => state.isSplittedView,
+      hideToast: (state) => state.hideToast,
       isGrid: (state) => state.isGrid
     }),
     currentTime: function () {
@@ -350,8 +352,7 @@ export default {
     },
     showError: function (newVal) {
       if (newVal && this.type === 'SubscriberError') {
-        const toast = useToast()
-        toast.error(this.message)
+        this.toast.showToast('error', this.message)
       } else {
         this.setShowError(false)
       }

--- a/src/components/VideoPlayerControls/VideoPlayerControlsSettings.vue
+++ b/src/components/VideoPlayerControls/VideoPlayerControlsSettings.vue
@@ -77,7 +77,7 @@ import VideoPlayerControlsSettingsSplitView from './VideoPlayerControlsSettingsS
 import VideoPlayerControlsSettingsLayout from './VideoPlayerControlsSettingsLayout.vue'
 
 import { mapGetters, mapState, mapMutations } from 'vuex'
-import { useToast } from 'vue-toastification'
+import CustomToast from '../../service/utils/toast'
 import { version } from '../../../package.json'
 
 export default {
@@ -110,7 +110,8 @@ export default {
         name: 'AudioFollowVideo',
         sourceId: 'AudioFollowVideo',
         trackId: null,
-      }
+      },
+      toast: null,
     }
   },
   computed: {
@@ -196,7 +197,7 @@ export default {
   },
   mounted() {
     this.viewerVersion = version ? 'v' + version : ''
-    this.toast = useToast()
+    this.toast = new CustomToast()
   },
   watch: {
     dropup: function (dropup) {
@@ -213,10 +214,7 @@ export default {
                 await selectSource({ kind: 'video', source })
                 await this.setMainLabel(source.name)
               } catch (error) {
-                this.toast.error(
-                  'There was an error selecting the desired source, try again',
-                  { timeout: 5000 }
-                )
+                this.toast.showToast('error','There was an error selecting the desired source, try again', { timeout: 5000 })
               }
             }
             this.setDropupSettings(
@@ -237,10 +235,7 @@ export default {
                 try {
                   await selectSource({ kind: 'audio', source })
                 } catch (error) {
-                  this.toast.error(
-                    'There was an error selecting the desired source, try again',
-                    { timeout: 5000 }
-                  )
+                  this.toast.showToast('error','There was an error selecting the desired source, try again',  { timeout: 5000 })
                 }
               }
             }

--- a/src/components/VideoPlayerMedia.vue
+++ b/src/components/VideoPlayerMedia.vue
@@ -51,7 +51,7 @@ import {
   setVideoPlayer,
 } from '../service/sdkManager'
 import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
-import { useToast } from 'vue-toastification'
+import CustomToast from '../service/utils/toast'
 
 export default {
   name: 'VideoPlayerMedia',
@@ -63,6 +63,7 @@ export default {
         reconnect: null,
         stats: null,
         broadcastEvent: null,
+        toast: null,
       },
     }
   },
@@ -148,21 +149,21 @@ export default {
   watch: {
     reconnectionStatus: function (isReconnecting) {
       let toastOptions;
-      const toast = useToast()
-      toast.clear()
+      this.toast = new CustomToast()
+      this.toast.clear()
       if (isReconnecting) {
         this.setIsSplittedView(false)
         const message = 'Connection lost. Retrying...'
         if (this.reconnection?.timeout) {
           toastOptions = { timeout: this.reconnection?.timeout }
         }
-        toast.warning(message, toastOptions)
+        this.toast.showToast('warning',message, toastOptions)
       } else {
         const setSplitView = (state) => {
           if (['connected'].includes(state)) {
             this.setIsSplittedView(this.previousSplitState)
             this.millicastView.removeListener('connectionStateChange', setSplitView)
-            toast.clear()
+            this.toast.clear()
           }
         }
         this.millicastView.on('connectionStateChange', setSplitView)
@@ -191,7 +192,6 @@ export default {
       await stopStream()
       await nextTick()
 
-      const toast = await useToast()
       initViewModule()
       try {
         await connectToStream()
@@ -199,7 +199,7 @@ export default {
           this.setAutoPlayMuted(false)
         }, 6000)
       } catch (e) {
-        toast.error(e.message)
+        this.toast.showToast('error', e.message)
       }
     },
   },

--- a/src/components/VideoPlayerReportModal.vue
+++ b/src/components/VideoPlayerReportModal.vue
@@ -58,8 +58,8 @@
 
 <script>
 import { Logger } from '@millicast/sdk'
-import { useToast } from 'vue-toastification'
 import { mapState } from 'vuex'
+import CustomToast from '../service/utils/toast'
 
 export default {
   name: 'VideoPlayerReportModal',
@@ -82,6 +82,7 @@ export default {
         url: '',
         log: [],
         statsInitialized: false,
+        toast: new CustomToast(),
       },
       localStats: [],
       isLoading: false,
@@ -99,7 +100,6 @@ export default {
       }
 
       this.report.log = log
-      const toast = useToast()
       try {
         this.isLoading = true
         const headers = { 'Content-Type': 'application/json' }
@@ -112,13 +112,13 @@ export default {
           headers,
           body: JSON.stringify(this.report),
         })
-        toast.success('Report sent successfully', { timeout: 3000 })
+        this.toast.showToast('success','Report sent successfully', { timeout: 3000 })
       } catch (err) {
         let message = "Error: couldn't send report"
         if (err.response?.data) {
           message += ', ' + err.response.data
         }
-        toast.error(message, { timeout: 3000 })
+        this.toast.showToast('error',message, { timeout: 3000 })
       } finally {
         this.isLoading = false
         this.close()

--- a/src/components/VideoPlayerSideVideoSources.vue
+++ b/src/components/VideoPlayerSideVideoSources.vue
@@ -39,6 +39,7 @@ import {
   projectVideo,
   unprojectMultiview,
 } from '../service/sdkManager'
+import CustomToast from '../service/utils/toast'
 
 export default {
   name: 'VideoPlayerSideVideoSources',
@@ -47,7 +48,8 @@ export default {
       indexSourceProjectedInMain: null,
       indexMainMediaSource: 0,
       playerRef: null,
-      enableClick: true
+      enableClick: true,
+      toast: new CustomToast()
     }
   },
   computed: {
@@ -148,13 +150,9 @@ export default {
         try {
           await selectSource({ kind: 'audio', source: audioSource })
         } catch (error) {
-          this.toast.error(
-            'There was an error selecting the desired source, try again',
-            { timeout: 5000 }
-          )
+          this.toast.showToast('error', 'There was an error selecting the desired source, try again', { timeout: 5000 })
         }
       }
-
       this.enableClick = true
     },
   },

--- a/src/service/utils/toast.js
+++ b/src/service/utils/toast.js
@@ -1,0 +1,60 @@
+import { useToast } from 'vue-toastification'
+import store from '../../../src/store'
+
+const TYPE = {
+  SUCCESS: "success",
+  ERROR: "error",
+  WARNING: "warning",
+  INFO: "info"
+}
+
+class CustomToast {
+  constructor() {
+    this.toast = useToast()
+    this.store = store
+  }
+
+  showToast(type, message, options) {
+    this.toast = useToast()
+    this.toast.clear()
+    if (this.shouldShowError(type)) {
+      this.showToaster(type, message, options)
+    }
+  }
+
+  showToaster(type, message, options) {
+    switch (type) {
+      case TYPE.ERROR:
+        this.toast.error(message,options)
+        break
+      case TYPE.WARNING:
+        this.toast.warning(message,options)
+        break
+      case TYPE.INFO:
+        this.toast.info(message,options)
+        break
+      case TYPE.SUCCESS:
+        this.toast.success(message,options)
+        break
+      default:
+        break
+    }
+  }
+
+  shouldShowError(type) {
+    const hideToast = this.store?._state?.data?.Controls.hideToast
+    return !(hideToast ? hideToast.includes(type) : false)
+  }
+
+  clear() {
+    this.toast = useToast()
+    this.toast.clear()
+  }
+
+  updateDefaults(options) {
+    this.toast = useToast()
+    this.toast.updateDefaults(options)
+  }
+}
+
+export default CustomToast

--- a/src/service/viewerOptions.js
+++ b/src/service/viewerOptions.js
@@ -19,6 +19,7 @@ export const defaultViewerOptions = {
   layout: null,
   showLabels: true,
   startingQuality: null,
+  hideToast: null,
   mainLabel: null
 }
 
@@ -38,6 +39,7 @@ export default function processViewerOptions({
   layout,
   showLabels,
   startingQuality,
+  hideToast,
   mainLabel
 }) {
   const options = {}
@@ -70,6 +72,10 @@ export default function processViewerOptions({
   if (startingQuality !== null) {
     options.startingQuality = startingQuality
     store.commit('Controls/setIsSelectingLayer', true)
+  }
+  if (hideToast !== null) {
+    options.hideToast = hideToast
+    store.commit('Controls/setHideToastError', hideToast)
   }
   if (mainLabel) {
     options.mainLabel = mainLabel

--- a/src/store/modules/controls.js
+++ b/src/store/modules/controls.js
@@ -27,6 +27,7 @@ const defaulState = {
   previousSplitState: false,
   isGrid: false,
   isSelectingLayer: false,
+  hideToast: false,
   selectingLayerTimeouts: null
 }
 
@@ -143,6 +144,9 @@ export default {
     },
     setIsSelectingLayer(state, isSelectingLayer) {
       state.isSelectingLayer = isSelectingLayer
+    },
+    setHideToastError(state, hideToast) {
+      state.hideToast = hideToast
     },
     setSelectingLayerTimeout(state, selectingLayerTimeout) {
       state.selectingLayerTimeouts = selectingLayerTimeout


### PR DESCRIPTION
Release of Viewer Plugin v1.4.0. The release includes:

**Added**
- New option parameter called `hideToast` which allows hiding a specific type of toast notification. To hide multiple toast types, separate them using `,`. Possible values: `success`, `error`, `warning`, `info`.