### PR TITLE
Fix / Missing stats on stream restart

### DIFF
--- a/src/service/utils/sources.js
+++ b/src/service/utils/sources.js
@@ -180,7 +180,6 @@ const deleteSource = (kind, sourceId) => {
     }
 
     commit('Sources/removeTransceiverSourceState', sourceId)
-    commit('Sources/removeTrackIdMidMapping', sourceCurrentMid)
   }
 
   commit('Sources/removeSourceRemoteTrack', sourceId)

--- a/src/store/modules/sources.js
+++ b/src/store/modules/sources.js
@@ -121,9 +121,6 @@ export default {
         }
       }
     },
-    removeTrackIdMidMapping(state, mid) {
-      delete state.trackIdMidMap[mid]
-    },
     setMainLabel(state, label) {
       state.mainLabel = label
     },


### PR DESCRIPTION
When a stream is restarted some stats are missing on the viewer. To fix it I removed the remove trackId mid-mapping change we added for dropped sources.