### PR TITLE
Feature / Add metadata in the paramOptions to dispatch it to parent node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.4.2",
             "license": "See in LICENSE file",
             "dependencies": {
-                "@millicast/sdk": "^0.1.43",
+                "@millicast/sdk": "^0.2.0",
                 "bootstrap": "github:millicast/bootstrap#ml-viewer",
                 "bootstrap-icons": "github:millicast/icons#ml-viewer",
                 "can-autoplay": "^3.0.0",
@@ -1821,6 +1821,14 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@dolbyio/webrtc-stats": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@dolbyio/webrtc-stats/-/webrtc-stats-0.4.0.tgz",
+            "integrity": "sha512-u4OrGbhUn4LM3Ihtoexye+q6eT2jcHsrwVkhFV28DqGLOmy5HJ/5Rt1eoy2+GPErYFWJ0ezLAw8suU5ZBJK4Vw==",
+            "dependencies": {
+                "js-logger": "^1.6.1"
+            }
+        },
         "node_modules/@hapi/address": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -1927,14 +1935,16 @@
             }
         },
         "node_modules/@millicast/sdk": {
-            "version": "0.1.43",
-            "resolved": "https://registry.npmjs.org/@millicast/sdk/-/sdk-0.1.43.tgz",
-            "integrity": "sha512-LGOWYrmV1Xh5iD++bMBMdD19fOND/l7cJsbCJW6ruoE7YNQyKi6yT3ayzDI+NLfvmPvXKkOaDjqWUDdd7BjsSA==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@millicast/sdk/-/sdk-0.2.0.tgz",
+            "integrity": "sha512-V8+WM/BlryI2SAU8sQUk6rw7l9cpdMnI6Xejco1VCxCXnR2U4/TEomqbSRuzCwUKQvGXHnxywncYJs3DumV5NQ==",
             "dependencies": {
+                "@dolbyio/webrtc-stats": "^0.4.0",
                 "@types/node": "^18.11.10",
                 "Base64": "^1.1.0",
                 "buffer": "^6.0.3",
                 "events": "^3.3.0",
+                "joi": "^17.12.0",
                 "js-logger": "^1.6.1",
                 "jsdoc-i18n-plugin": "^0.0.3",
                 "jwt-decode": "^3.1.2",
@@ -1977,6 +1987,29 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/@sideway/address": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+            "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+            "dependencies": {
+                "@hapi/hoek": "^9.0.0"
+            }
+        },
+        "node_modules/@sideway/address/node_modules/@hapi/hoek": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+            "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        },
+        "node_modules/@sideway/formula": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+            "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+        },
+        "node_modules/@sideway/pinpoint": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+            "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
         },
         "node_modules/@soda/friendly-errors-webpack-plugin": {
             "version": "1.8.1",
@@ -9411,6 +9444,31 @@
             "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.1.0.tgz",
             "integrity": "sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==",
             "dev": true
+        },
+        "node_modules/joi": {
+            "version": "17.13.3",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+            "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+            "dependencies": {
+                "@hapi/hoek": "^9.3.0",
+                "@hapi/topo": "^5.1.0",
+                "@sideway/address": "^4.1.5",
+                "@sideway/formula": "^3.0.1",
+                "@sideway/pinpoint": "^2.0.0"
+            }
+        },
+        "node_modules/joi/node_modules/@hapi/hoek": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+            "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        },
+        "node_modules/joi/node_modules/@hapi/topo": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+            "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+            "dependencies": {
+                "@hapi/hoek": "^9.0.0"
+            }
         },
         "node_modules/jquery": {
             "version": "3.7.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "README.md"
     ],
     "dependencies": {
-        "@millicast/sdk": "^0.1.43",
+        "@millicast/sdk": "^0.2.0",
         "bootstrap": "github:millicast/bootstrap#ml-viewer",
         "bootstrap-icons": "github:millicast/icons#ml-viewer",
         "can-autoplay": "^3.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,7 +54,8 @@ export default {
           showLabels: this.paramsOptions?.showLabels ?? true,
           startingQuality: this.paramsOptions?.startingQuality,
           hideToast: this.paramsOptions?.hideToast,
-          mainLabel: this.paramsOptions?.mainLabel ?? 'Main'
+          mainLabel: this.paramsOptions?.mainLabel ?? 'Main',
+          metadata: this.paramsOptions?.metadata
         })
       }
       processEnvironmentOptions(this.paramsOptions?.environment)

--- a/src/service/utils/viewConnection.js
+++ b/src/service/utils/viewConnection.js
@@ -85,6 +85,7 @@ export const handleConnectToStream = async () => {
     if (state.Params.viewer.audioOnly) {connectOptions.disableVideo = true}
     if (state.Params.viewer.videoOnly) {connectOptions.disableAudio = true}
     if (state.Params.viewer.forcePlayoutDelay) {connectOptions.forcePlayoutDelay = state.Params.viewer.forcePlayoutDelay}
+    if (state.Params.viewer.metadata) {connectOptions.metadata = state.Params.viewer.metadata}
     await millicastView.connect(connectOptions)
     addSignalingMigrateListener()
   } catch (e) {

--- a/src/service/utils/viewConnection.js
+++ b/src/service/utils/viewConnection.js
@@ -124,7 +124,7 @@ export const setTrackEvent = () => {
   })
 
   if (state.Params.viewer.metadata) {
-    millicastView.on('onMetadata', (metadata) => {
+    millicastView.on('metadata', (metadata) => {
       const metadataEvent = new CustomEvent("metadata", { detail: { metadata } })
       window.dispatchEvent(metadataEvent)
     })

--- a/src/service/utils/viewConnection.js
+++ b/src/service/utils/viewConnection.js
@@ -122,6 +122,24 @@ export const setTrackEvent = () => {
     }
     state.ViewConnection.trackEvent[event.track.kind].track = true
   })
+
+  if (state.Params.viewer.metadata) {
+    millicastView.on('onMetadata', (event) => {
+      const decoder = new TextDecoder()
+      const metadata = event.metadata
+      metadata.track = event.track
+      const uuid = metadata.uuid
+      metadata.uuid = uuid.reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '')
+      metadata.uuid = metadata.uuid.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, "$1-$2-$3-$4-$5")
+      if (metadata.timecode) {
+        metadata.timecode = decoder.decode(metadata.timecode)
+      } else if (metadata.unregistered) {
+        metadata.unregistered = decoder.decode(metadata.unregistered)
+      }
+      const metadataEvent = new CustomEvent("metadata", { detail: { metadata } })
+      window.dispatchEvent(metadataEvent)
+    })
+  }
 }
 
 const setStream = async (entrySrcObject) => {

--- a/src/service/utils/viewConnection.js
+++ b/src/service/utils/viewConnection.js
@@ -124,18 +124,7 @@ export const setTrackEvent = () => {
   })
 
   if (state.Params.viewer.metadata) {
-    millicastView.on('onMetadata', (event) => {
-      const decoder = new TextDecoder()
-      const metadata = event.metadata
-      metadata.track = event.track
-      const uuid = metadata.uuid
-      metadata.uuid = uuid.reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '')
-      metadata.uuid = metadata.uuid.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, "$1-$2-$3-$4-$5")
-      if (metadata.timecode) {
-        metadata.timecode = decoder.decode(metadata.timecode)
-      } else if (metadata.unregistered) {
-        metadata.unregistered = decoder.decode(metadata.unregistered)
-      }
+    millicastView.on('onMetadata', (metadata) => {
       const metadataEvent = new CustomEvent("metadata", { detail: { metadata } })
       window.dispatchEvent(metadataEvent)
     })

--- a/src/service/viewerOptions.js
+++ b/src/service/viewerOptions.js
@@ -20,7 +20,8 @@ export const defaultViewerOptions = {
   showLabels: true,
   startingQuality: null,
   hideToast: null,
-  mainLabel: null
+  mainLabel: null,
+  metadata: false
 }
 
 export default function processViewerOptions({
@@ -40,7 +41,8 @@ export default function processViewerOptions({
   showLabels,
   startingQuality,
   hideToast,
-  mainLabel
+  mainLabel,
+  metadata
 }) {
   const options = {}
 
@@ -57,6 +59,7 @@ export default function processViewerOptions({
   options.audioFollowsVideo = audioFollowsVideo ?? false
   options.layout = layout
   options.showLabels = showLabels
+  options.metadata = metadata
   if (multisource) {
     store.commit('Controls/setIsSplittedView', true)
   }


### PR DESCRIPTION
When `metadata` option is true, it should:

- Start listening to metadata events emitted by the SDK
- Parse the metadata object with unregistered user data or timecode information
- Dispatch a `metadata` custom event to the window so that the parent node can listen to it.