### PR TITLE
v1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@millicast/vue-viewer-plugin",
-            "version": "1.4.2",
+            "version": "1.5.0",
             "license": "See in LICENSE file",
             "dependencies": {
                 "@millicast/sdk": "^0.2.0",
@@ -9468,8 +9468,7 @@
             "version": "9.3.0",
             "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
             "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-            "license": "BSD-3-Clause",
-            "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+            "license": "BSD-3-Clause"
         },
         "node_modules/joi/node_modules/@hapi/topo": {
             "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "private": false,
     "author": "Millicast, Inc.",
     "scripts": {


### PR DESCRIPTION
 Release of Viewer Plugin v1.5.0. The release includes:
    
**Added**
- Propagate contents of `onMetadata` event to consuming app
- Add diagnostics to `report feedback`
    
**Fixed**
- Clicking on media stats does not show media 
- Web viewer console error, undefined (reading 'mid')