### PR TITLE
v1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@millicast/vue-viewer-plugin",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "license": "See in LICENSE file",
             "dependencies": {
                 "@millicast/sdk": "latest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "private": false,
     "author": "Millicast, Inc.",
     "scripts": {


### PR DESCRIPTION
Release of Viewer Plugin v1.5.2. The release includes:

**Changed**
- Now, instead of using the `bitrate` attribute, we use the new SDK stats value `bitrateBitsPerSecond`.
    
**Fixed**
- Now, the stats `jitter` value has a fixed value of up to 2 decimal places