### PR TITLE
v1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@millicast/vue-viewer-plugin",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "license": "See in LICENSE file",
             "dependencies": {
                 "@millicast/sdk": "latest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1822,9 +1822,9 @@
             }
         },
         "node_modules/@dolbyio/webrtc-stats": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@dolbyio/webrtc-stats/-/webrtc-stats-0.4.0.tgz",
-            "integrity": "sha512-u4OrGbhUn4LM3Ihtoexye+q6eT2jcHsrwVkhFV28DqGLOmy5HJ/5Rt1eoy2+GPErYFWJ0ezLAw8suU5ZBJK4Vw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@dolbyio/webrtc-stats/-/webrtc-stats-1.0.2.tgz",
+            "integrity": "sha512-hpXUbtJl+yQOGBACWFfFsYFJrBbY8N+pdo5CHQVVKm4CvGaFai6gfW/ged0Hce9G/CvnF2HcZ54jhsnyMYwx4A==",
             "license": "MIT",
             "dependencies": {
                 "js-logger": "^1.6.1"
@@ -1936,12 +1936,12 @@
             }
         },
         "node_modules/@millicast/sdk": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@millicast/sdk/-/sdk-0.2.0.tgz",
-            "integrity": "sha512-V8+WM/BlryI2SAU8sQUk6rw7l9cpdMnI6Xejco1VCxCXnR2U4/TEomqbSRuzCwUKQvGXHnxywncYJs3DumV5NQ==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@millicast/sdk/-/sdk-0.2.1.tgz",
+            "integrity": "sha512-FDBQQUFlgqIqx14RPj36LxYxy2g9VILqVYLuI9FKULSHUPLBMTibqG4ItlUPtmHs1WCUNw6a00nMAx6tRTO1FA==",
             "license": "See in LICENSE file",
             "dependencies": {
-                "@dolbyio/webrtc-stats": "^0.4.0",
+                "@dolbyio/webrtc-stats": "^1.0.2",
                 "@types/node": "^18.11.10",
                 "Base64": "^1.1.0",
                 "buffer": "^6.0.3",
@@ -9487,7 +9487,8 @@
         "node_modules/js-logger": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/js-logger/-/js-logger-1.6.1.tgz",
-            "integrity": "sha512-yTgMCPXVjhmg28CuUH8CKjU+cIKL/G+zTu4Fn4lQxs8mRFH/03QTNvEFngcxfg/gRDiQAOoyCKmMTOm9ayOzXA=="
+            "integrity": "sha512-yTgMCPXVjhmg28CuUH8CKjU+cIKL/G+zTu4Fn4lQxs8mRFH/03QTNvEFngcxfg/gRDiQAOoyCKmMTOm9ayOzXA==",
+            "license": "MIT"
         },
         "node_modules/js-message": {
             "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@millicast/vue-viewer-plugin",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "private": false,
     "author": "Millicast, Inc.",
     "scripts": {

--- a/src/components/VideoPlayerStatsTable.vue
+++ b/src/components/VideoPlayerStatsTable.vue
@@ -74,11 +74,11 @@
       </tr>
       <tr v-if="video?.bitrate" class="row mx-0">
         <td class="col-6">Video Bitrate</td>
-        <td class="col-6">{{ formatBitrate(video.bitrate) }}</td>
+        <td class="col-6">{{ formatBitrate(video.bitrateBitsPerSecond) }}</td>
       </tr>
       <tr v-if="audio?.bitrate" class="row mx-0">
         <td class="col-6">Audio Bitrate</td>
-        <td class="col-6">{{ formatBitrate(audio.bitrate) }}</td>
+        <td class="col-6">{{ formatBitrate(audio.bitrateBitsPerSecond) }}</td>
       </tr>
       <tr v-if="video?.totalBytesReceived" class="row mx-0">
         <td class="col-6">Video Total Received</td>
@@ -202,7 +202,7 @@ export default {
       return formatBitsRecursive(value)
     },
     formatMilliseconds(value) {
-      return `${(value || 0) * 1000} ms`
+      return `${+((value || 0) * 1000).toFixed(2)} ms`
     },
     handleSourceChange() {
       const mid = this.selectedSourceMid ?? 0


### PR DESCRIPTION
Release of Viewer Plugin v1.5.2. The release includes:

**Changed**
- Now, instead of using the `bitrate` attribute, we use the new SDK
stats value `bitrateBitsPerSecond`.
    
**Fixed**
- Now, the stats `jitter` value has a fixed value of up to 2 decimal
places