### PR TITLE
DIOS-7181: stream ID now showing in media stats table

### DIFF
--- a/src/components/VideoPlayerStatsTable.vue
+++ b/src/components/VideoPlayerStatsTable.vue
@@ -45,6 +45,12 @@
           {{ millicastView.signaling.subscriberId }}
         </td>
       </tr>
+      <tr v-if="castOptions?.streamId" class="row mx-0">
+        <td class="col-6">Stream Id</td>
+        <td class="col-6">
+          {{ castOptions.streamId }}
+        </td>
+      </tr>
       <tr v-if="millicastView?.signaling?.streamViewId" class="row mx-0">
         <td class="col-6">Stream View Id</td>
         <td class="col-5 overflow-ellipsis">
@@ -217,7 +223,8 @@ export default {
   computed: {
     ...mapState('Controls', [
       'isMobile',
-      'isSplittedView'
+      'isSplittedView',
+      'castOptions'
     ]),
     ...mapState('ViewConnection', {
       millicastView: (state) => state.millicastView,


### PR DESCRIPTION
References https://jira.dolby.net/jira/browse/DIOS-7181

Screenshots of change:
![StreamID](https://github.com/user-attachments/assets/6fe53283-4d31-4380-b479-b5630d48342b)
![GotStreamID](https://github.com/user-attachments/assets/6106e6e8-faae-4441-8132-8d5ac20c0a78)
