### PR TITLE
added stream id to web stats table

### DIFF
--- a/src/components/VideoPlayerStatsTable.vue
+++ b/src/components/VideoPlayerStatsTable.vue
@@ -39,6 +39,12 @@
       :style="[isMobile ? 'overflow-x: auto;' : 'overflow-x: hidden;']"
       class="text-left videoStats"
     >
+      <tr v-if="streamId" class="row mx-0">
+        <td class="col-6">Stream Id</td>
+        <td class="col-6">
+          {{ streamId }}
+        </td>
+      </tr>
       <tr v-if="millicastView?.signaling?.subscriberId" class="row mx-0">
         <td class="col-6">Server Id</td>
         <td class="col-6">
@@ -215,6 +221,9 @@ export default {
     },
   },
   computed: {
+    ...mapState('Params', {
+      streamId: (state) => state.viewer.streamId,
+    }),
     ...mapState('Controls', [
       'isMobile',
       'isSplittedView'


### PR DESCRIPTION
Added stream Id to the web stats table using 'viewer.streamId' instead of the castOptions.streamId.
![DisplayingStreamId](https://github.com/user-attachments/assets/745f2d5c-3c67-491a-a673-3cce89c421b1)
