### PR TITLE
Fix / Layer selection from side source selected

### DIFF
--- a/src/service/utils/layers.js
+++ b/src/service/utils/layers.js
@@ -100,8 +100,11 @@ export const handleSelectQuality = (media) => {
   }
   //Replaced select with project, as select can cause errors when used with transcoders
   const source = state.Sources.selectedVideoSource
-  const mediaLayers =
-    state.Layers.medias[source.mid]?.layers || state.Layers.medias['0']?.layers
+  let layerIdx = source?.mid
+  if (!state.Layers.medias[layerIdx]?.layers) {
+    layerIdx = '0'
+  }
+  const mediaLayers = state.Layers.medias[layerIdx]?.layers
   const quality = mediaLayers.find(
     (layer) => layer.simulcastIdx === media.simulcastIdx
   )


### PR DESCRIPTION
Fix medias.layers undefined when trying to select quality on side source selected

This will impact in the use case where main does not have simulcast, and multisource view is shown, and quality is intended to be selected, as the media server (websocket) will throw an internal server error upon project being sent.