### PR TITLE
Workflows: use app-token

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -33,7 +33,6 @@ jobs:
     with:
       bump_version: ${{ inputs.bump_version }}
       prerelease_id: ${{ inputs.prerelease_id }}
-      use_workflow_token: true
 
   build-publish:
     uses: ./.github/workflows/npm-build-publish.yml


### PR DESCRIPTION
Actually we do need to use app-token because only the app is allowed to commit directly to main.
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/millicast/vue-viewer-plugin/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
