### PR TITLE
Build: require status job name

### DIFF
--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   dryrun:
-    name: "build ${{ github.ref_name }}"
+    name: "Build dryrun"
     runs-on: ubuntu-latest
     container: node:24-alpine
     permissions:

--- a/index.js
+++ b/index.js
@@ -20,8 +20,6 @@ const filterBeforeCreate = (toast, toasts) => {
   return toast
 }
 
-break build
-
 export default {
   install(vue, options) {
     if (!options.store) {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ const filterBeforeCreate = (toast, toasts) => {
   return toast
 }
 
+break build
+
 export default {
   install(vue, options) {
     if (!options.store) {


### PR DESCRIPTION
Need non-dynamic job name to match for build status checks.
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/millicast/vue-viewer-plugin/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->